### PR TITLE
Improve OCR logging

### DIFF
--- a/ai_extractor.py
+++ b/ai_extractor.py
@@ -1,5 +1,4 @@
 # KYO QA ServiceNow AI Extractor - SYNTAX FIXED VERSION
-from version import VERSION
 import re
 from datetime import datetime
 from logging_utils import setup_logger, log_info, log_error, log_warning
@@ -72,9 +71,9 @@ def bulletproof_extraction(text, filename):
     log_info(logger, f"Starting bulletproof extraction for: {filename}")
     log_info(logger, f"Text length: {len(text)} characters")
     
-    # Show first 500 chars for debugging
+    # Only log the presence of text to avoid leaking PDF content
     if len(text) > 0:
-        log_info(logger, f"Text preview: {repr(text[:500])}")
+        log_info(logger, f"Text available for {filename} ({len(text)} characters)")
     else:
         log_warning(logger, f"No text to process for {filename}")
         return data

--- a/ocr_utils.py
+++ b/ocr_utils.py
@@ -1,5 +1,4 @@
 # KYO QA ServiceNow OCR Utilities
-from version import VERSION
 
 import fitz  # PyMuPDF
 import os
@@ -54,25 +53,30 @@ def extract_text_from_pdf(pdf_path: Path | str) -> str:
     """Extract text from a PDF file, using OCR if needed."""
     try:
         pdf_path = Path(pdf_path)
-        
+        log_info(logger, f"Starting text extraction for {pdf_path.name}")
+
         # First try standard text extraction
         with fitz.open(pdf_path) as doc:
             text = "".join(page.get_text() for page in doc)
             
         # If we got meaningful text, return it
         if text and len(text.strip()) > 50:
-            log_info(logger, f"Extracted text directly from {pdf_path}")
+            log_info(logger, f"Extracted text directly from {pdf_path.name}")
+            log_info(logger, f"Finished text extraction for {pdf_path.name} - {len(text)} chars")
             return text
             
         # If text extraction failed and Tesseract is available, try OCR
         if TESSERACT_AVAILABLE:
-            log_info(logger, f"Attempting OCR on {pdf_path}")
-            return extract_text_with_ocr(pdf_path)
+            log_info(logger, f"Attempting OCR on {pdf_path.name}")
+            ocr_text = extract_text_with_ocr(pdf_path)
+            log_info(logger, f"Finished text extraction for {pdf_path.name} - {len(ocr_text)} chars")
+            return ocr_text
         else:
-            log_warning(logger, f"No text found in {pdf_path} and OCR not available")
+            log_warning(logger, f"No text found in {pdf_path.name} and OCR not available")
+            log_info(logger, f"Finished text extraction for {pdf_path.name} - {len(text)} chars")
             return text
     except Exception as exc:
-        log_error(logger, f"Failed to extract text from {pdf_path}: {exc}")
+        log_error(logger, f"Failed to extract text from {pdf_path.name}: {exc}")
         return ""
 
 def extract_text_with_ocr(pdf_path: Path | str) -> str:
@@ -80,8 +84,9 @@ def extract_text_with_ocr(pdf_path: Path | str) -> str:
     if not TESSERACT_AVAILABLE:
         log_warning(logger, "Tesseract OCR not available")
         return ""
-        
+
     try:
+        log_info(logger, f"Starting OCR for {Path(pdf_path).name}")
         # Import here to avoid errors if not installed
         import pytesseract
         from PIL import Image

--- a/tests/test_ocr_utils.py
+++ b/tests/test_ocr_utils.py
@@ -1,0 +1,27 @@
+import unittest
+from pathlib import Path
+import fitz
+import ocr_utils
+
+class TestOCRUtilsLogging(unittest.TestCase):
+    def setUp(self):
+        self.pdf_path = Path("test_sample.pdf")
+        doc = fitz.open()
+        page = doc.new_page()
+        page.insert_text((72, 72), "Hello world")
+        doc.save(self.pdf_path)
+        doc.close()
+
+    def tearDown(self):
+        if self.pdf_path.exists():
+            self.pdf_path.unlink()
+
+    def test_extract_text_logging(self):
+        with self.assertLogs(ocr_utils.logger.name, level="INFO") as cm:
+            text = ocr_utils.extract_text_from_pdf(self.pdf_path)
+        self.assertTrue(any("Starting text extraction" in msg for msg in cm.output))
+        self.assertTrue(any("Finished text extraction" in msg for msg in cm.output))
+        self.assertEqual(text.strip(), "Hello world")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add log statements for start/finish in `extract_text_from_pdf`
- log presence of text instead of preview in `ai_extractor`
- add OCR logging unit test

## Testing
- `flake8 ai_extractor.py ocr_utils.py tests/test_ocr_utils.py`
- `python -m unittest discover -s tests`


------
https://chatgpt.com/codex/tasks/task_e_6859eb790cd4832eaba5af5bb57c9c2c