### PR TITLE
Fix lambda closure for exception handling

### DIFF
--- a/KYO-QA-ServiceNow-Knowledge-Tool-v24.0.6/kyo_qa_tool_app.py
+++ b/KYO-QA-ServiceNow-Knowledge-Tool-v24.0.6/kyo_qa_tool_app.py
@@ -907,9 +907,9 @@ class KyoQAToolApp(tk.Tk):
 
         except Exception as e:
             log_exception(logger, f"Processing error: {e}")
-            self.after(0, lambda: self.safe_log_message(f"CRITICAL ERROR: {e}", "error"))
+            self.after(0, lambda e=e: self.safe_log_message(f"CRITICAL ERROR: {e}", "error"))
             create_failure_log("Critical processing failure", str(e))
-            self.after(0, lambda: messagebox.showerror("Critical Error", f"Error: {e}"))
+            self.after(0, lambda e=e: messagebox.showerror("Critical Error", f"Error: {e}"))
         
         finally:
             # Reset UI state

--- a/kyo_qa_tool_app.py
+++ b/kyo_qa_tool_app.py
@@ -907,9 +907,9 @@ class KyoQAToolApp(tk.Tk):
 
         except Exception as e:
             log_exception(logger, f"Processing error: {e}")
-            self.after(0, lambda: self.safe_log_message(f"CRITICAL ERROR: {e}", "error"))
+            self.after(0, lambda e=e: self.safe_log_message(f"CRITICAL ERROR: {e}", "error"))
             create_failure_log("Critical processing failure", str(e))
-            self.after(0, lambda: messagebox.showerror("Critical Error", f"Error: {e}"))
+            self.after(0, lambda e=e: messagebox.showerror("Critical Error", f"Error: {e}"))
         
         finally:
             # Reset UI state

--- a/tests/test_lambda_capture.py
+++ b/tests/test_lambda_capture.py
@@ -1,0 +1,16 @@
+import unittest
+
+
+class TestLambdaExceptionCapture(unittest.TestCase):
+    def test_capture_exception_in_lambda(self):
+        try:
+            raise ValueError("first")
+        except Exception as e:
+            def func(e=e):
+                return f"error: {e}"
+            e = ValueError("second")
+        self.assertEqual(func(), "error: first")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- ensure exception objects are captured in lambdas
- add regression test for lambda capture

## Testing
- `python -m unittest discover -s tests -v`


------
https://chatgpt.com/codex/tasks/task_e_6859ef35e904832ead37a8b188b10a79