### PR TITLE
Add pytest tests and workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,23 @@
+name: Run Pytest
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Run tests
+        run: pytest

--- a/tests/test_ai_extract.py
+++ b/tests/test_ai_extract.py
@@ -1,0 +1,45 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import types
+
+# Stub out PyMuPDF to avoid heavy dependency
+fitz_stub = types.ModuleType('fitz')
+class DummyDoc:
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        pass
+    @property
+    def metadata(self):
+        return {}
+    def __len__(self):
+        return 1
+fitz_stub.open = lambda *args, **kwargs: DummyDoc()
+sys.modules.setdefault('fitz', fitz_stub)
+
+import ai_extractor
+
+
+def test_ai_extract_basic(monkeypatch, tmp_path):
+    text = (
+        "Service Bulletin Ref. No. 2M8-0016 (E099)\n"
+        "Model: TASKalfa 4000i\n"
+        "Subject: Drum issue\n"
+        "January 15, 2024"
+    )
+
+    # Avoid PDF metadata reading
+    monkeypatch.setattr(ai_extractor, 'get_pdf_metadata', lambda p: {'author': 'Kyo Author'})
+
+    pdf = tmp_path / "QA_20146_E099-2M8-0016.pdf"
+    pdf.write_text("dummy")
+
+    result = ai_extractor.ai_extract(text, pdf)
+
+    assert result["full_qa_number"] == "2M8-0016"
+    assert result["short_qa_number"] == "E099"
+    assert result["models"] == "TASKalfa 4000i"
+    assert result["subject"] == "Drum issue"
+    assert result["published_date"] == "2024-01-15"
+    assert result["author"] == "Kyo Author"

--- a/tests/test_excel_generator.py
+++ b/tests/test_excel_generator.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import openpyxl
+from excel_generator import generate_excel
+
+
+def test_generate_excel_writes_rows(tmp_path):
+    headers = ["Active", "Article type", "Author"]
+    template = tmp_path / "template.xlsx"
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "Page 1"
+    ws.append(headers)
+    wb.save(template)
+
+    data = [{"Active": "TRUE", "Article type": "HTML", "Author": "Tester"}]
+    output = tmp_path / "out.xlsx"
+    generate_excel(data, output, template)
+
+    result_wb = openpyxl.load_workbook(output)
+    result_ws = result_wb["Page 1"]
+
+    assert result_ws.max_row == 2
+    assert [cell.value for cell in result_ws[2]] == ["TRUE", "HTML", "Tester"]

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from processing_engine import map_to_servicenow_format
+
+
+def test_map_to_servicenow_flags_missing_fields():
+    data = {
+        "full_qa_number": "2M8-0016",
+        "short_qa_number": "E099",
+        "models": "",
+        "subject": "",
+        "published_date": "2024-01-15",
+        "author": "Author",
+        "document_type": "Service Bulletin",
+    }
+
+    record = map_to_servicenow_format(data, "test.pdf")
+
+    assert record["needs_review"] is True


### PR DESCRIPTION
## Summary
- add new GitHub Actions workflow to run pytest
- create pytest tests for `ai_extract`, `map_to_servicenow_format` and Excel generation

## Testing
- `pytest -q`
- `flake8 . | head`

------
https://chatgpt.com/codex/tasks/task_e_6859ebacefa0832e8f6365e87adccbfa