### PR TITLE
Add lambda capture unit test

### DIFF
--- a/tests/test_lambda_capture_messagebox.py
+++ b/tests/test_lambda_capture_messagebox.py
@@ -1,0 +1,16 @@
+import unittest
+
+
+class TestLambdaExceptionCaptureMessageBox(unittest.TestCase):
+    def test_capture_exception_in_messagebox_lambda(self):
+        try:
+            raise RuntimeError("one")
+        except Exception as e:
+            def func(e=e):
+                return f"Error: {e}"
+            e = RuntimeError("two")
+        self.assertEqual(func(), "Error: one")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a regression test that ensures exceptions captured in lambdas remain stable

## Testing
- `pytest -q`
- `flake8 tests/test_lambda_capture_messagebox.py`
- `flake8 | head -n 20` *(fails: style errors)*

------
https://chatgpt.com/codex/tasks/task_e_6859f2394bc4832ebd425bb00225dda7