### PR TITLE
Fix CI pytest install and add version test

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -25,15 +25,19 @@ jobs:
         python-version: "3.10"
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m venv .venv
+        source .venv/bin/activate
+        pip install --upgrade pip setuptools
         pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |
+        source .venv/bin/activate
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
+        source .venv/bin/activate
         pytest

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,17 @@
+# flake8: noqa
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import unittest
+from version import get_version
+
+
+class TestVersion(unittest.TestCase):
+    def test_get_version(self):
+        self.assertEqual(get_version(), "24.0.6")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix GitHub Actions workflow by creating a virtual environment
- install `pytest` and `flake8` in that venv
- activate the venv when linting and testing
- add a small unit test for `get_version`

## Testing
- `flake8 tests/test_version.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859f166fde4832e86cccc009d5c02bf