### PR TITLE
Refactor exception imports

### DIFF
--- a/KYO-QA-ServiceNow-Knowledge-Tool-v24.0.6/processing_engine.py
+++ b/KYO-QA-ServiceNow-Knowledge-Tool-v24.0.6/processing_engine.py
@@ -8,7 +8,15 @@ import fitz
 from datetime import datetime, timedelta
 
 from logging_utils import setup_logger, log_info, log_error, log_warning
-from custom_exceptions import *
+# Import custom exceptions explicitly so linters know where they come from
+from custom_exceptions import (
+    QAExtractionError,
+    FileProcessingError,
+    ExcelGenerationError,
+    OCRError,
+    ZipExtractionError,
+    ConfigurationError,
+)
 from file_utils import get_temp_dir, cleanup_temp_files, is_pdf, is_zip, save_txt
 from ocr_utils import extract_text_from_pdf
 from ai_extractor import ai_extract

--- a/processing_engine.py
+++ b/processing_engine.py
@@ -8,7 +8,15 @@ import fitz
 from datetime import datetime, timedelta
 
 from logging_utils import setup_logger, log_info, log_error, log_warning
-from custom_exceptions import *
+# Import custom exceptions explicitly so linters know where they come from
+from custom_exceptions import (
+    QAExtractionError,
+    FileProcessingError,
+    ExcelGenerationError,
+    OCRError,
+    ZipExtractionError,
+    ConfigurationError,
+)
 from file_utils import get_temp_dir, cleanup_temp_files, is_pdf, is_zip, save_txt
 from ocr_utils import extract_text_from_pdf
 from ai_extractor import ai_extract

--- a/tests/test_processing_engine_imports.py
+++ b/tests/test_processing_engine_imports.py
@@ -1,0 +1,20 @@
+import importlib
+import os
+import sys
+
+# Ensure the project root is on the import path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import custom_exceptions
+
+# Ensure processing_engine exposes same exception classes
+processing_engine = importlib.import_module('processing_engine')
+
+
+def test_exception_exports():
+    assert processing_engine.QAExtractionError is custom_exceptions.QAExtractionError
+    assert processing_engine.FileProcessingError is custom_exceptions.FileProcessingError
+    assert processing_engine.ExcelGenerationError is custom_exceptions.ExcelGenerationError
+    assert processing_engine.OCRError is custom_exceptions.OCRError
+    assert processing_engine.ZipExtractionError is custom_exceptions.ZipExtractionError
+    assert processing_engine.ConfigurationError is custom_exceptions.ConfigurationError


### PR DESCRIPTION
## Summary
- import custom exceptions explicitly
- test that `processing_engine` exports the custom exception classes

## Testing
- `flake8 processing_engine.py KYO-QA-ServiceNow-Knowledge-Tool-v24.0.6/processing_engine.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859eba8adf0832e831cae467e616917