### PR TITLE
Fix lambda exception capture

### DIFF
--- a/KYO-QA-ServiceNow-Knowledge-Tool-v24.0.6/kyo_qa_tool_app.py
+++ b/KYO-QA-ServiceNow-Knowledge-Tool-v24.0.6/kyo_qa_tool_app.py
@@ -906,10 +906,11 @@ class KyoQAToolApp(tk.Tk):
                 self.after(0, lambda: messagebox.showerror("Processing Failed", "No output file was created."))
 
         except Exception as e:
-            log_exception(logger, f"Processing error: {e}")
-            self.after(0, lambda: self.safe_log_message(f"CRITICAL ERROR: {e}", "error"))
-            create_failure_log("Critical processing failure", str(e))
-            self.after(0, lambda: messagebox.showerror("Critical Error", f"Error: {e}"))
+            error_msg = str(e)
+            log_exception(logger, f"Processing error: {error_msg}")
+            self.after(0, lambda m=error_msg: self.safe_log_message(f"CRITICAL ERROR: {m}", "error"))
+            create_failure_log("Critical processing failure", error_msg)
+            self.after(0, lambda m=error_msg: messagebox.showerror("Critical Error", f"Error: {m}"))
         
         finally:
             # Reset UI state

--- a/kyo_qa_tool_app.py
+++ b/kyo_qa_tool_app.py
@@ -906,10 +906,11 @@ class KyoQAToolApp(tk.Tk):
                 self.after(0, lambda: messagebox.showerror("Processing Failed", "No output file was created."))
 
         except Exception as e:
-            log_exception(logger, f"Processing error: {e}")
-            self.after(0, lambda: self.safe_log_message(f"CRITICAL ERROR: {e}", "error"))
-            create_failure_log("Critical processing failure", str(e))
-            self.after(0, lambda: messagebox.showerror("Critical Error", f"Error: {e}"))
+            error_msg = str(e)
+            log_exception(logger, f"Processing error: {error_msg}")
+            self.after(0, lambda m=error_msg: self.safe_log_message(f"CRITICAL ERROR: {m}", "error"))
+            create_failure_log("Critical processing failure", error_msg)
+            self.after(0, lambda m=error_msg: messagebox.showerror("Critical Error", f"Error: {m}"))
         
         finally:
             # Reset UI state

--- a/tests/test_lambda_capture.py
+++ b/tests/test_lambda_capture.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+def test_lambda_captures_exception_message():
+    try:
+        raise ValueError('boom')
+    except Exception as e:
+        error_msg = str(e)
+        func = lambda m=error_msg: f"CRITICAL ERROR: {m}"
+    # 'e' is out of scope here
+    assert func() == 'CRITICAL ERROR: boom'


### PR DESCRIPTION
## Summary
- capture exception strings before using them in lambdas
- mirror the fix in the duplicate UI file
- add a small unit test demonstrating lambda capture

## Testing
- `pytest -q`
- `python -m py_compile kyo_qa_tool_app.py KYO-QA-ServiceNow-Knowledge-Tool-v24.0.6/kyo_qa_tool_app.py tests/test_lambda_capture.py`


------
https://chatgpt.com/codex/tasks/task_e_6859eba59db0832e8f11447cea53e194