### PR TITLE
Remove unused imports and clean startup

### DIFF
--- a/KYO-QA-ServiceNow-Knowledge-Tool-v24.0.6/ai_extractor.py
+++ b/KYO-QA-ServiceNow-Knowledge-Tool-v24.0.6/ai_extractor.py
@@ -1,5 +1,4 @@
 # KYO QA ServiceNow AI Extractor - SYNTAX FIXED VERSION
-from version import VERSION
 import re
 from datetime import datetime
 from logging_utils import setup_logger, log_info, log_error, log_warning

--- a/KYO-QA-ServiceNow-Knowledge-Tool-v24.0.6/config.py
+++ b/KYO-QA-ServiceNow-Knowledge-Tool-v24.0.6/config.py
@@ -1,5 +1,4 @@
 # KYO QA ServiceNow Configuration for Adaptable Standardization
-from version import VERSION
 
 # QA Number Extraction Patterns
 QA_NUMBER_PATTERNS = [

--- a/KYO-QA-ServiceNow-Knowledge-Tool-v24.0.6/custom_exceptions.py
+++ b/KYO-QA-ServiceNow-Knowledge-Tool-v24.0.6/custom_exceptions.py
@@ -1,5 +1,4 @@
 # KYO QA ServiceNow Custom Exceptions
-from version import VERSION
 
 class QAExtractionError(Exception):
     """Raised when QA data extraction fails"""

--- a/KYO-QA-ServiceNow-Knowledge-Tool-v24.0.6/data_harvesters.py
+++ b/KYO-QA-ServiceNow-Knowledge-Tool-v24.0.6/data_harvesters.py
@@ -1,5 +1,4 @@
 # KYO QA ServiceNow Data Harvesters
-from version import VERSION
 import re
 from logging_utils import setup_logger, log_info, log_error, log_warning
 from config import (

--- a/KYO-QA-ServiceNow-Knowledge-Tool-v24.0.6/excel_generator.py
+++ b/KYO-QA-ServiceNow-Knowledge-Tool-v24.0.6/excel_generator.py
@@ -1,5 +1,4 @@
 # KYO QA ServiceNow Excel Generator v24.0.6
-from version import VERSION
 import pandas as pd, shutil, openpyxl
 from openpyxl.utils.dataframe import dataframe_to_rows
 from logging_utils import setup_logger, log_info, log_error, log_warning

--- a/KYO-QA-ServiceNow-Knowledge-Tool-v24.0.6/file_utils.py
+++ b/KYO-QA-ServiceNow-Knowledge-Tool-v24.0.6/file_utils.py
@@ -1,5 +1,4 @@
 # KYO QA ServiceNow File Utilities
-from version import VERSION
 
 import os
 import shutil

--- a/KYO-QA-ServiceNow-Knowledge-Tool-v24.0.6/logging_utils.py
+++ b/KYO-QA-ServiceNow-Knowledge-Tool-v24.0.6/logging_utils.py
@@ -5,7 +5,6 @@ import logging
 import sys
 from pathlib import Path
 from datetime import datetime
-import os
 from logging.handlers import RotatingFileHandler
 
 # Create logs directory

--- a/KYO-QA-ServiceNow-Knowledge-Tool-v24.0.6/ocr_utils.py
+++ b/KYO-QA-ServiceNow-Knowledge-Tool-v24.0.6/ocr_utils.py
@@ -1,5 +1,4 @@
 # KYO QA ServiceNow OCR Utilities
-from version import VERSION
 
 import fitz  # PyMuPDF
 import os

--- a/KYO-QA-ServiceNow-Knowledge-Tool-v24.0.6/processing_engine.py
+++ b/KYO-QA-ServiceNow-Knowledge-Tool-v24.0.6/processing_engine.py
@@ -1,5 +1,4 @@
 # KYO QA ServiceNow Processing Engine - FINALIZED MODEL MAPPING
-from version import VERSION
 import os
 import re
 import zipfile

--- a/KYO-QA-ServiceNow-Knowledge-Tool-v24.0.6/start_tool.py
+++ b/KYO-QA-ServiceNow-Knowledge-Tool-v24.0.6/start_tool.py
@@ -6,7 +6,6 @@ import sys
 import subprocess
 import shutil
 import time
-import os
 import threading
 from pathlib import Path
 from logging_utils import setup_logger, log_info, log_error, log_warning
@@ -231,9 +230,6 @@ def check_and_install_requirements():
     spinner.start("Checking existing packages...")
     
     try:
-        # Read requirements
-        with open(req_file, 'r') as f:
-            requirements = [line.strip() for line in f if line.strip() and not line.startswith('#')]
         
         # Test critical packages
         critical_packages = ['pandas', 'PyMuPDF', 'openpyxl']

--- a/ai_extractor.py
+++ b/ai_extractor.py
@@ -1,5 +1,4 @@
 # KYO QA ServiceNow AI Extractor - SYNTAX FIXED VERSION
-from version import VERSION
 import re
 from datetime import datetime
 from logging_utils import setup_logger, log_info, log_error, log_warning

--- a/config.py
+++ b/config.py
@@ -1,5 +1,4 @@
 # KYO QA ServiceNow Configuration for Adaptable Standardization
-from version import VERSION
 
 # QA Number Extraction Patterns
 QA_NUMBER_PATTERNS = [

--- a/custom_exceptions.py
+++ b/custom_exceptions.py
@@ -1,5 +1,4 @@
 # KYO QA ServiceNow Custom Exceptions
-from version import VERSION
 
 class QAExtractionError(Exception):
     """Raised when QA data extraction fails"""

--- a/data_harvesters.py
+++ b/data_harvesters.py
@@ -1,5 +1,4 @@
 # KYO QA ServiceNow Data Harvesters
-from version import VERSION
 import re
 from logging_utils import setup_logger, log_info, log_error, log_warning
 from config import (

--- a/excel_generator.py
+++ b/excel_generator.py
@@ -1,5 +1,4 @@
 # KYO QA ServiceNow Excel Generator v24.0.6
-from version import VERSION
 import pandas as pd, shutil, openpyxl
 from openpyxl.utils.dataframe import dataframe_to_rows
 from logging_utils import setup_logger, log_info, log_error, log_warning

--- a/file_utils.py
+++ b/file_utils.py
@@ -1,5 +1,4 @@
 # KYO QA ServiceNow File Utilities
-from version import VERSION
 
 import os
 import shutil

--- a/logging_utils.py
+++ b/logging_utils.py
@@ -5,7 +5,6 @@ import logging
 import sys
 from pathlib import Path
 from datetime import datetime
-import os
 from logging.handlers import RotatingFileHandler
 
 # Create logs directory

--- a/ocr_utils.py
+++ b/ocr_utils.py
@@ -1,5 +1,4 @@
 # KYO QA ServiceNow OCR Utilities
-from version import VERSION
 
 import fitz  # PyMuPDF
 import os

--- a/processing_engine.py
+++ b/processing_engine.py
@@ -1,5 +1,4 @@
 # KYO QA ServiceNow Processing Engine - FINALIZED MODEL MAPPING
-from version import VERSION
 import os
 import re
 import zipfile

--- a/start_tool.py
+++ b/start_tool.py
@@ -6,7 +6,6 @@ import sys
 import subprocess
 import shutil
 import time
-import os
 import threading
 from pathlib import Path
 from logging_utils import setup_logger, log_info, log_error, log_warning
@@ -231,9 +230,6 @@ def check_and_install_requirements():
     spinner.start("Checking existing packages...")
     
     try:
-        # Read requirements
-        with open(req_file, 'r') as f:
-            requirements = [line.strip() for line in f if line.strip() and not line.startswith('#')]
         
         # Test critical packages
         critical_packages = ['pandas', 'PyMuPDF', 'openpyxl']

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,0 +1,20 @@
+import sys, pathlib; sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+import os
+from pathlib import Path
+from logging_utils import create_success_log, create_failure_log
+
+
+def test_create_success_log(tmp_path):
+    log_file = tmp_path / 'success.md'
+    path = create_success_log('All good', output_file=log_file)
+    assert Path(path).exists()
+    content = Path(path).read_text()
+    assert 'KYO QA Tool Success Log' in content
+
+
+def test_create_failure_log(tmp_path):
+    log_file = tmp_path / 'fail.md'
+    path = create_failure_log('oops', 'traceback', output_file=log_file)
+    assert Path(path).exists()
+    content = Path(path).read_text()
+    assert 'KYO QA Tool Failure Log' in content


### PR DESCRIPTION
## Summary
- clean up `VERSION` imports across helper modules
- remove unused `os` imports from `logging_utils`
- drop unused `requirements` variable from `start_tool`
- add basic tests for logging utilities

## Testing
- `pytest -q`
- `python3 -m flake8`

------
https://chatgpt.com/codex/tasks/task_e_6859eba74704832eacbdcc48cebe91e2