### PR TITLE
Unify processing path logic

### DIFF
--- a/kyo_qa_tool_app.py
+++ b/kyo_qa_tool_app.py
@@ -12,7 +12,7 @@ import re
 
 # --- Safe Import with Fallbacks ---
 try:
-    from processing_engine import process_files, process_pdf_list
+    from processing_engine import process_files, process_paths
     from file_utils import ensure_folders, cleanup_temp_files, open_file
     from logging_utils import (
         setup_logger,
@@ -42,7 +42,7 @@ except ImportError as e:
             ocr_cb(False)
         return excel_path, ["review_doc.pdf"], max(0, random.randint(-1, 1))
 
-    def process_pdf_list(files, excel_path, template_path, progress_cb, ocr_cb, cancel_event):
+    def process_paths(files, excel_path, template_path, progress_cb, ocr_cb, cancel_event):
         for i, f in enumerate(files):
             if cancel_event.is_set():
                 break
@@ -878,7 +878,7 @@ class KyoQAToolApp(tk.Tk):
                 if hasattr(self, 'progress_frame'):
                     self.after(0, lambda: self.progress_frame.show(file_count))
                 
-                self.result_file, review_files, fail_count = process_pdf_list(
+                self.result_file, review_files, fail_count = process_paths(
                     self.selected_files, excel_path, template_path, progress_cb, ocr_cb, self.cancel_event
                 )
 

--- a/tests/test_processing_pipeline.py
+++ b/tests/test_processing_pipeline.py
@@ -4,16 +4,16 @@ import threading
 import processing_engine
 
 
-def test_process_pdf_list_returns_excel(tmp_path):
+def test_process_paths_returns_excel(tmp_path):
     dummy_pdf = tmp_path / "file.pdf"
     dummy_pdf.write_text("dummy")
     excel_out = tmp_path / "out.xlsx"
     template = tmp_path / "template.xlsx"
 
-    with patch("processing_engine._process_file_list") as mock_proc, \
+    with patch("processing_engine.process_single_pdf") as mock_proc, \
          patch("processing_engine.generate_excel") as mock_gen, \
          patch("processing_engine.get_temp_dir") as mock_temp:
-        mock_proc.return_value = ([{"file_name": dummy_pdf.name}], [])
+        mock_proc.return_value = {"file_name": dummy_pdf.name}
         mock_gen.return_value = str(excel_out)
         mock_temp.return_value = tmp_path
 
@@ -23,7 +23,7 @@ def test_process_pdf_list_returns_excel(tmp_path):
         def ocr(_):
             pass
         cancel_event = threading.Event()
-        result = processing_engine.process_pdf_list(
+        result = processing_engine.process_paths(
             [dummy_pdf], excel_out, template, progress, ocr, cancel_event
         )
 


### PR DESCRIPTION
## Summary
- merge duplicate processing functions into `process_paths`
- update GUI app to use new function
- adapt pipeline unit test for new API

## Testing
- `python -m py_compile processing_engine.py kyo_qa_tool_app.py tests/test_processing_pipeline.py`
- `pytest tests/test_processing_pipeline.py::test_process_paths_returns_excel -q`

------
https://chatgpt.com/codex/tasks/task_e_6859fbc47d4c832eae633d1a7496ad09