### PR TITLE
Add Excel formatting and tests

### DIFF
--- a/excel_generator.py
+++ b/excel_generator.py
@@ -1,18 +1,37 @@
 # KYO QA ServiceNow Excel Generator v24.0.6
 import pandas as pd, shutil, openpyxl
 from openpyxl.utils.dataframe import dataframe_to_rows
+from openpyxl.styles import Alignment, PatternFill
 from logging_utils import setup_logger, log_info, log_error, log_warning
 from custom_exceptions import ExcelGenerationError
 
 logger = setup_logger("excel_generator")
 
-def _use_template_excel(df, output_path, template_path):
+def _use_template_excel(df, output_path, template_path, highlight_map=None):
+    """Write the DataFrame to the Excel template and apply formatting."""
     try:
         shutil.copy2(template_path, output_path)
         workbook = openpyxl.load_workbook(output_path)
         sheet = workbook["Page 1"] if "Page 1" in workbook.sheetnames else workbook.active
-        for row in dataframe_to_rows(df, index=False, header=False):
+
+        start_row = sheet.max_row + 1
+        for idx, row in enumerate(dataframe_to_rows(df, index=False, header=False), start=start_row):
             sheet.append(row)
+            for cell in sheet[idx]:
+                cell.alignment = Alignment(wrap_text=True)
+
+            if highlight_map:
+                status = highlight_map.get(idx - start_row)
+                if status:
+                    fill_color = "FFEB9C" if status == "needs_review" else "FFC7CE"
+                    fill = PatternFill(start_color=fill_color, end_color=fill_color, fill_type="solid")
+                    for cell in sheet[idx]:
+                        cell.fill = fill
+
+        for column_cells in sheet.columns:
+            length = max(len(str(cell.value)) if cell.value else 0 for cell in column_cells)
+            sheet.column_dimensions[column_cells[0].column_letter].width = length + 2
+
         workbook.save(output_path)
         log_info(logger, f"Successfully saved data to {output_path}")
         return str(output_path)
@@ -23,6 +42,12 @@ def generate_excel(all_results, output_path, template_path):
     try:
         if not all_results: raise ExcelGenerationError("No data to generate.")
         df = pd.DataFrame(all_results)
+        highlight_map = {}
+        for idx, row in df.iterrows():
+            if row.get("needs_review"):
+                highlight_map[idx] = "needs_review"
+            if str(row.get("status", "")).lower() == "failed":
+                highlight_map[idx] = "failed"
         
         if template_path:
             log_info(logger, f"Aligning data with template: {template_path}")
@@ -44,7 +69,7 @@ def generate_excel(all_results, output_path, template_path):
             
             df = df[template_headers]
         
-        return _use_template_excel(df, output_path, template_path)
+        return _use_template_excel(df, output_path, template_path, highlight_map)
     except Exception as e:
         log_error(logger, f"Excel generation failed: {e}")
         raise ExcelGenerationError(f"Failed to generate Excel file: {e}")

--- a/tests/test_excel_generator.py
+++ b/tests/test_excel_generator.py
@@ -23,3 +23,30 @@ def test_generate_excel_writes_rows(tmp_path):
 
     assert result_ws.max_row == 2
     assert [cell.value for cell in result_ws[2]] == ["TRUE", "HTML", "Tester"]
+
+
+def test_generate_excel_formats_rows(tmp_path):
+    headers = ["Active", "Article type", "Author"]
+    template = tmp_path / "template.xlsx"
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "Page 1"
+    ws.append(headers)
+    wb.save(template)
+
+    data = [
+        {"Active": "TRUE", "Article type": "HTML", "Author": "Tester", "needs_review": True},
+        {"Active": "FALSE", "Article type": "PDF", "Author": "Agent", "status": "failed"},
+    ]
+    output = tmp_path / "out.xlsx"
+    generate_excel(data, output, template)
+
+    result_wb = openpyxl.load_workbook(output)
+    result_ws = result_wb["Page 1"]
+
+    assert result_ws.column_dimensions["A"].width >= len("Active")
+    assert all(cell.alignment.wrap_text for cell in result_ws[2])
+    first_row_colors = {cell.fill.start_color.rgb for cell in result_ws[2]}
+    second_row_colors = {cell.fill.start_color.rgb for cell in result_ws[3]}
+    assert first_row_colors == {"00FFEB9C"}
+    assert second_row_colors == {"00FFC7CE"}


### PR DESCRIPTION
## Summary
- set column widths and wrap text in Excel output
- highlight rows that need review or failed
- test formatting in generated Excel files

## Testing
- `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
- `flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics`
- `pytest -q` *(fails: ImportError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6859fbc72134832e9c05ed5b4976c44f