### PR TITLE
Add log_safe helper and truncate sensitive logs

### DIFF
--- a/ai_extractor.py
+++ b/ai_extractor.py
@@ -1,7 +1,7 @@
 # KYO QA ServiceNow AI Extractor - SYNTAX FIXED VERSION
 import re
 from datetime import datetime
-from logging_utils import setup_logger, log_info, log_error, log_warning
+from logging_utils import setup_logger, log_info, log_error, log_warning, log_safe
 from config import STANDARDIZATION_RULES
 from ocr_utils import get_pdf_metadata
 from data_harvesters import identify_document_type
@@ -30,11 +30,11 @@ def ai_extract(text, pdf_path):
 
         # Log the final result for debugging
         log_info(logger, f"FINAL EXTRACTION RESULT for {filename}:")
-        log_info(logger, f"  Full QA: '{data.get('full_qa_number', '')}'")
-        log_info(logger, f"  Short QA: '{data.get('short_qa_number', '')}'")
-        log_info(logger, f"  Models: '{data.get('models', '')}'")
-        log_info(logger, f"  Subject: '{data.get('subject', '')}'")
-        log_info(logger, f"  Date: '{data.get('published_date', '')}'")
+        log_safe(logger, f"  Full QA: '{data.get('full_qa_number', '')}'")
+        log_safe(logger, f"  Short QA: '{data.get('short_qa_number', '')}'")
+        log_safe(logger, f"  Models: '{data.get('models', '')}'")
+        log_safe(logger, f"  Subject: '{data.get('subject', '')}'")
+        log_safe(logger, f"  Date: '{data.get('published_date', '')}'")
 
         return data
 
@@ -249,7 +249,7 @@ def bulletproof_extraction(text, filename):
             
             if len(subject) > 5:
                 data["subject"] = subject
-                log_info(logger, f"Subject found: {data['subject'][:100]}...")
+                log_safe(logger, f"Subject found: {data['subject'][:100]}...")
                 subject_extracted = True
                 break
 
@@ -259,7 +259,7 @@ def bulletproof_extraction(text, filename):
         clean_subject = re.sub(r'QA_[A-Z0-9]+_', '', clean_subject)
         clean_subject = re.sub(r'_SB.*', '', clean_subject)
         data["subject"] = clean_subject.strip()
-        log_info(logger, f"Using filename as subject: {data['subject']}")
+        log_safe(logger, f"Using filename as subject: {data['subject']}")
 
     return data
 

--- a/logging_utils.py
+++ b/logging_utils.py
@@ -80,6 +80,20 @@ def log_critical(logger: logging.Logger, message: str) -> None:
     """Log a critical message."""
     logger.critical(message)
 
+def log_safe(logger: logging.Logger, message: str, level: str = "info", max_length: int = 250) -> None:
+    """Log a message safely by stripping newlines and truncating large blocks.
+
+    Args:
+        logger: Logger instance to use.
+        message: The text to log.
+        level: Logging level name (default ``info``).
+        max_length: Maximum characters to log before truncating.
+    """
+    clean = message.replace("\n", " ").replace("\r", " ")
+    if len(clean) > max_length:
+        clean = clean[:max_length] + "..."
+    getattr(logger, level, logger.info)(clean)
+
 def log_exception(logger: logging.Logger, message: str) -> None:
     """Log an exception with traceback."""
     logger.exception(message)

--- a/processing_engine.py
+++ b/processing_engine.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import fitz
 from datetime import datetime, timedelta
 
-from logging_utils import setup_logger, log_info, log_error, log_warning
+from logging_utils import setup_logger, log_info, log_error, log_warning, log_safe
 # Import custom exceptions explicitly so linters know where they come from
 from custom_exceptions import (
     QAExtractionError,
@@ -70,10 +70,10 @@ def process_single_pdf(pdf_path, txt_output_dir, progress_cb, ocr_cb, cancel_eve
     
     # Log what we extracted for debugging
     log_info(logger, f"Raw extracted data for {filename}:")
-    log_info(logger, f"  Full QA: '{extracted_data.get('full_qa_number', '')}'")
-    log_info(logger, f"  Short QA: '{extracted_data.get('short_qa_number', '')}'") 
-    log_info(logger, f"  Models: '{extracted_data.get('models', '')}'")
-    log_info(logger, f"  Subject: '{extracted_data.get('subject', '')}'")
+    log_safe(logger, f"  Full QA: '{extracted_data.get('full_qa_number', '')}'")
+    log_safe(logger, f"  Short QA: '{extracted_data.get('short_qa_number', '')}'")
+    log_safe(logger, f"  Models: '{extracted_data.get('models', '')}'")
+    log_safe(logger, f"  Subject: '{extracted_data.get('subject', '')}'")
 
     # Validate and enhance the data
     validated_data = validate_and_enhance_data(extracted_data, filename)
@@ -168,7 +168,7 @@ def validate_and_enhance_data(extracted_data, filename):
         models_clean = models_clean.rstrip('.,;')
         extracted_data["models"] = models_clean
         
-        log_info(logger, f"Cleaned models for {filename}: '{models_clean}'")
+        log_safe(logger, f"Cleaned models for {filename}: '{models_clean}'")
     else:
         log_warning(logger, f"No models found for {filename}")
     
@@ -239,7 +239,7 @@ def map_to_servicenow_format(extracted_data, filename):
     models_data = ""
     if extracted_data.get("models") and extracted_data["models"] not in ["Not Found", ""]:
         models_data = extracted_data["models"]
-        log_info(logger, f"Setting models data for {filename}: '{models_data}'")
+        log_safe(logger, f"Setting models data for {filename}: '{models_data}'")
     else:
         log_warning(logger, f"No models data to set for {filename}")
         
@@ -287,10 +287,10 @@ def map_to_servicenow_format(extracted_data, filename):
     
     # Log the final mapping for debugging
     log_info(logger, f"Final ServiceNow record for {filename}:")
-    log_info(logger, f"  Meta: '{servicenow_record['Meta']}'") 
-    log_info(logger, f"  Meta Description: '{servicenow_record['Meta Description']}'")
-    log_info(logger, f"  models: '{servicenow_record['models']}'")
-    log_info(logger, f"  Short description: '{servicenow_record['Short description'][:100]}...'")
+    log_safe(logger, f"  Meta: '{servicenow_record['Meta']}'")
+    log_safe(logger, f"  Meta Description: '{servicenow_record['Meta Description']}'")
+    log_safe(logger, f"  models: '{servicenow_record['models']}'")
+    log_safe(logger, f"  Short description: '{servicenow_record['Short description'][:100]}...'")
     
     return servicenow_record
 

--- a/tests/test_ai_extract.py
+++ b/tests/test_ai_extract.py
@@ -4,6 +4,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 import types
 
 # Stub out PyMuPDF to avoid heavy dependency
+_orig_fitz = sys.modules.get('fitz')
 fitz_stub = types.ModuleType('fitz')
 class DummyDoc:
     def __enter__(self):
@@ -19,6 +20,11 @@ fitz_stub.open = lambda *args, **kwargs: DummyDoc()
 sys.modules.setdefault('fitz', fitz_stub)
 
 import ai_extractor
+
+if _orig_fitz is not None:
+    sys.modules['fitz'] = _orig_fitz
+else:
+    del sys.modules['fitz']
 
 
 def test_ai_extract_basic(monkeypatch, tmp_path):

--- a/tests/test_ai_extractor.py
+++ b/tests/test_ai_extractor.py
@@ -6,8 +6,11 @@ import sys
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 sys.path.insert(0, BASE_DIR)
 
+_orig_ocr_utils = sys.modules.get('ocr_utils')
+_orig_data_harvesters = sys.modules.get('data_harvesters')
 sys.modules['ocr_utils'] = types.SimpleNamespace(get_pdf_metadata=lambda x: {})
 sys.modules['data_harvesters'] = types.SimpleNamespace(identify_document_type=lambda x: '')
+_orig_logging_utils = sys.modules.get('logging_utils')
 sys.modules['logging_utils'] = types.SimpleNamespace(
     setup_logger=lambda name: None,
     log_info=lambda *args, **kwargs: None,
@@ -17,6 +20,19 @@ sys.modules['logging_utils'] = types.SimpleNamespace(
 sys.modules['config'] = types.SimpleNamespace(STANDARDIZATION_RULES={"default_author": ""})
 
 from ai_extractor import extract_qa_numbers, extract_models, extract_dates
+
+if _orig_logging_utils is not None:
+    sys.modules['logging_utils'] = _orig_logging_utils
+else:
+    del sys.modules['logging_utils']
+if _orig_ocr_utils is not None:
+    sys.modules['ocr_utils'] = _orig_ocr_utils
+else:
+    del sys.modules['ocr_utils']
+if _orig_data_harvesters is not None:
+    sys.modules['data_harvesters'] = _orig_data_harvesters
+else:
+    del sys.modules['data_harvesters']
 
 SAMPLE_TEXT = """
 Service Bulletin

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,20 +1,46 @@
 import sys, pathlib; sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 import os
 from pathlib import Path
-from logging_utils import create_success_log, create_failure_log
+import logging
+import io
+import importlib
+
+def load_utils():
+    import logging_utils
+    return importlib.reload(logging_utils)
 
 
 def test_create_success_log(tmp_path):
+    utils = load_utils()
     log_file = tmp_path / 'success.md'
-    path = create_success_log('All good', output_file=log_file)
+    path = utils.create_success_log('All good', output_file=log_file)
     assert Path(path).exists()
     content = Path(path).read_text()
     assert 'KYO QA Tool Success Log' in content
 
 
 def test_create_failure_log(tmp_path):
+    utils = load_utils()
     log_file = tmp_path / 'fail.md'
-    path = create_failure_log('oops', 'traceback', output_file=log_file)
+    path = utils.create_failure_log('oops', 'traceback', output_file=log_file)
     assert Path(path).exists()
     content = Path(path).read_text()
     assert 'KYO QA Tool Failure Log' in content
+
+
+def test_log_safe_truncates():
+    utils = load_utils()
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(logging.Formatter('%(message)s'))
+    logger = logging.getLogger('safe_test')
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+    long_message = 'A' * 300
+    utils.log_safe(logger, long_message, max_length=50)
+
+    handler.flush()
+    logged = stream.getvalue().strip()
+    assert logged.endswith('...')
+    assert len(logged) <= 53


### PR DESCRIPTION
## Summary
- add `log_safe` helper for truncating log messages
- sanitize extracted data logging
- reload actual modules after stubbing in tests
- cover new helper with unit test

## Testing
- `pytest tests/test_ai_extract.py tests/test_ai_extractor.py tests/test_logging_utils.py tests/test_mapping.py tests/test_processing_engine_imports.py tests/test_processing_pipeline.py tests/test_start_tool.py tests/test_version.py tests/test_file_utils.py tests/test_excel_generator.py tests/test_imports.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6859fbf018a8832e9fe7cab148587b70