### PR TITLE
Handle Excel creation without template

### DIFF
--- a/excel_generator.py
+++ b/excel_generator.py
@@ -92,7 +92,14 @@ def generate_excel(all_results, output_path, template_path):
             df = df[template_headers]
             return _use_template_excel(df, output_path, template_path)
         else:
-            return _create_new_excel(df, output_path)
+            log_info(logger, "No template provided. Creating new workbook.")
+            df.to_excel(output_path, index=False)
+            workbook = openpyxl.load_workbook(output_path)
+            sheet = workbook.active
+            _apply_formatting(sheet)
+            workbook.save(output_path)
+            log_info(logger, f"Successfully saved data to {output_path}")
+            return str(output_path)
     except Exception as e:
         log_error(logger, f"Excel generation failed: {e}")
         raise ExcelGenerationError(f"Failed to generate Excel file: {e}")

--- a/tests/test_excel_generator.py
+++ b/tests/test_excel_generator.py
@@ -12,3 +12,13 @@ def test_generate_excel_no_template(tmp_path):
     sheet = wb.active
     headers = [cell.value for cell in sheet[1]]
     assert headers == ["A", "B"]
+
+
+def test_generate_excel_no_template_returns_path(tmp_path):
+    data = [{"A": "first", "B": "second"}]
+    out_file = tmp_path / "out.xlsx"
+    returned = generate_excel(data, out_file, None)
+    assert returned == str(out_file)
+    wb = openpyxl.load_workbook(out_file)
+    sheet = wb.active
+    assert sheet["A2"].alignment.wrap_text


### PR DESCRIPTION
## Summary
- support generating a new workbook directly when no template is given
- log when template is absent
- add regression test for Excel generation without a template

## Testing
- `flake8 excel_generator.py | head -n 20`
- `flake8 tests/test_excel_generator.py | cat`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a408b9e48832e88a1fc2640bf6ad8