### PR TITLE
Fix column width calculation in Excel generator

### DIFF
--- a/excel_generator.py
+++ b/excel_generator.py
@@ -12,11 +12,16 @@ REVIEW_FILL = PatternFill(start_color="FFF3BF", end_color="FFF3BF", fill_type="s
 
 def _apply_formatting(sheet: openpyxl.worksheet.worksheet.Worksheet):
     """Apply default formatting to the given worksheet."""
-    # Ensure columns have a reasonable width
-    for cell in sheet[1]:
-        col_dim = sheet.column_dimensions[cell.column_letter]
-        if not col_dim.width or col_dim.width <= 8.43:
-            col_dim.width = max(len(str(cell.value)) + 2, 15)
+    # Ensure columns have a reasonable width based on all cell contents
+    for col_cells in sheet.columns:
+        column_letter = col_cells[0].column_letter
+        col_dim = sheet.column_dimensions[column_letter]
+        max_length = 0
+        for cell in col_cells:
+            value = str(cell.value) if cell.value is not None else ""
+            if len(value) > max_length:
+                max_length = len(value)
+        col_dim.width = max(max_length + 2, 15)
 
     # Determine index of needs_review column if present
     review_idx = None

--- a/tests/test_excel_generator.py
+++ b/tests/test_excel_generator.py
@@ -22,3 +22,14 @@ def test_generate_excel_no_template_returns_path(tmp_path):
     wb = openpyxl.load_workbook(out_file)
     sheet = wb.active
     assert sheet["A2"].alignment.wrap_text
+
+
+def test_column_width_expands_with_long_value(tmp_path):
+    long_text = "A" * 40
+    data = [{"A": long_text}]
+    out_file = tmp_path / "long.xlsx"
+    generate_excel(data, out_file, None)
+    wb = openpyxl.load_workbook(out_file)
+    sheet = wb.active
+    width = sheet.column_dimensions["A"].width
+    assert width and width > 20


### PR DESCRIPTION
## Summary
- enhance `_apply_formatting` to size columns by the longest value
- add unit test checking column width expansion

## Testing
- `ruff check excel_generator.py tests/test_excel_generator.py | head -n 20`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a42d5f8f8832e8e1fa9d0198547b3