### PR TITLE
feat: add conditional formatting and auto width

### DIFF
--- a/tests/test_excel_generator.py
+++ b/tests/test_excel_generator.py
@@ -22,3 +22,21 @@ def test_generate_excel_no_template_returns_path(tmp_path):
     wb = openpyxl.load_workbook(out_file)
     sheet = wb.active
     assert sheet["A2"].alignment.wrap_text
+
+
+def test_review_rows_are_colored(tmp_path):
+    data = [{"A": "text", "needs_review": True}]
+    out_file = tmp_path / "review.xlsx"
+    generate_excel(data, out_file, None)
+    wb = openpyxl.load_workbook(out_file)
+    sheet = wb.active
+    assert sheet["A2"].fill.start_color.rgb.endswith("FFF3BF")
+
+
+def test_auto_column_width(tmp_path):
+    data = [{"A": "short"}, {"A": "this is a very long cell"}]
+    out_file = tmp_path / "width.xlsx"
+    generate_excel(data, out_file, None)
+    wb = openpyxl.load_workbook(out_file)
+    sheet = wb.active
+    assert sheet.column_dimensions["A"].width > 15


### PR DESCRIPTION
## Summary
- auto-fit Excel columns by scanning all cell values
- highlight rows based on `needs_review` or `status`
- add unit tests for auto width and row highlighting

## Testing
- `flake8 excel_generator.py tests/test_excel_generator.py | head`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a42faa5ac832ea0246590790bf961