### PR TITLE
Update docs for v24.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,23 @@
 - README and requirements updated for Python 3.11.x and latest packages.
 - Every file and log stamped with version.
 - Ready for robust testing, extension, and team deployment.
+
+## v24.0.2 (2024-06-21)
+- Introduced basic unit tests and GitHub workflow for continuous integration.
+- Enhanced logging statements throughout the codebase.
+
+## v24.0.3 (2024-06-22)
+- Consolidated the startup script to handle package installation automatically.
+- Improved CI configuration and exception handling.
+
+## v24.0.4 (2024-06-23)
+- Refactored extraction logic into a dedicated `QAExtractor` class.
+- Removed unused imports and tightened error handling.
+
+## v24.0.5 (2024-06-24)
+- Added Excel formatting support and corresponding tests.
+- Optimized modules and cleaned obsolete directories.
+
+## v24.0.6 (2024-06-25)
+- Added fallback for missing Excel templates.
+- General code cleanup and formatting fixes.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# KYO QA ServiceNow Knowledge Tool v24.0.1
+# KYO QA ServiceNow Knowledge Tool v24.0.6
 
 ## How to Set Up and Run (Modular, Fully Logged)
 
@@ -8,7 +8,7 @@
 - **Optional:** All dependencies listed in `requirements.txt` (auto-installed if you run `start_tool.py`)
 
 ### 2. Folder Structure
-KYO_QA_ServiceNow_Knowledge_Tool_v24.0.1/
+KYO_QA_ServiceNow_Knowledge_Tool_v24.0.6/
 ├── run_tool.bat
 ├── start_tool.py
 ├── requirements.txt
@@ -26,7 +26,7 @@ KYO_QA_ServiceNow_Knowledge_Tool_v24.0.1/
 ├── logs/(auto-created)
 ├── output/(auto-created)
 └── venv/(auto-created)
-# KYO QA ServiceNow Knowledge Tool v24.0.1 – Directory Breakdown
+# KYO QA ServiceNow Knowledge Tool v24.0.6 – Directory Breakdown
 
 This tool extracts model info, QA/SB numbers, and descriptions from Kyocera QA/service PDFs using OCR + pattern recognition. It outputs a ServiceNow-ready Excel file and logs every step. No PDFs are retained.
 
@@ -95,16 +95,15 @@ This tool extracts model info, QA/SB numbers, and descriptions from Kyocera QA/s
     - Logs and output are saved in `/logs/` and `/output/` folders.
 
 ### Install Dependencies
-If you plan to run or test the tool locally, first install the required Python
-packages with the helper script:
+If you plan to run or test the tool locally, install the Python packages listed in
+`requirements.txt`:
 
 ```bash
-cd KYO_QA_ServiceNow_Knowledge_Tool_v24.0.1
-./scripts/setup_env.sh
+cd KYO_QA_ServiceNow_Knowledge_Tool_v24.0.6
+python -m pip install -r requirements.txt
 ```
 
-The test suite relies on these packages, so make sure to run the script before
-executing `pytest`.
+The test suite relies on these packages, so install them before executing `pytest`.
 
 ### Development and Testing
 After installing the dependencies, run the test suite with:
@@ -115,11 +114,11 @@ pytest -q
 
 The tests rely on `pandas`, `PyMuPDF`, and the rest of the packages listed in
 `requirements.txt`. If `PyMuPDF` is missing you will see import errors. As of
-v24.0.1, unused packages `xlsxwriter` and `halo` were removed to keep the
+v24.0.6, unused packages `xlsxwriter` and `halo` were removed to keep the
 environment lean.
 
 ### 4. Versioning
-- This is the modular, logging-enabled release: **v24.0.1**
+- This is the modular, logging-enabled release: **v24.0.6**
 - Each file and log is stamped with its version.
 - All updates are tracked in `CHANGELOG.md`.
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,4 @@
+from version import get_version
+
+def test_get_version():
+    assert get_version() == "24.0.6"


### PR DESCRIPTION
## Summary
- update README references to v24.0.6
- remove mention of scripts/setup_env.sh
- add changelog notes through v24.0.6
- add unit test for version consistency

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a42c17644832e9fa17f989fabd73a