### PR TITLE
Add tests for PDF processing and file copy retry

### DIFF
--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -1,0 +1,25 @@
+import shutil
+
+import file_utils
+
+
+def test_copy_file_safely_retries(tmp_path, mocker):
+    src = tmp_path / "src.txt"
+    src.write_text("data")
+    dest = tmp_path / "dest.txt"
+
+    call_count = {"n": 0}
+    real_copy = shutil.copy2
+
+    def fake_copy(s, d, *, follow_symlinks=True):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise IOError("fail")
+        return real_copy(s, d, follow_symlinks=follow_symlinks)
+
+    mocker.patch("file_utils.shutil.copy2", side_effect=fake_copy)
+
+    assert file_utils.copy_file_safely(src, dest, retries=2, wait_time=0)
+    assert call_count["n"] == 2
+    assert dest.read_text() == "data"
+

--- a/tests/test_processing_engine.py
+++ b/tests/test_processing_engine.py
@@ -1,0 +1,62 @@
+import sys
+import types
+import threading
+from pathlib import Path
+
+import fitz
+import importlib
+
+# Set up dummy extract.ai_extractor before importing processing_engine
+class DummyExtractor:
+    def extract(self, text, path):
+        return {
+            "full_qa_number": "2ND-0001",
+            "short_qa_number": "0001",
+            "models": "ModelX",
+            "subject": "Test",
+            "published_date": "2020-01-01",
+            "author": "Tester",
+        }
+
+extract_pkg = types.ModuleType("extract")
+ai_module = types.ModuleType("extract.ai_extractor")
+ai_module.QAExtractor = DummyExtractor
+extract_pkg.ai_extractor = ai_module
+sys.modules.setdefault("extract", extract_pkg)
+sys.modules.setdefault("extract.ai_extractor", ai_module)
+
+processing_engine = importlib.import_module("processing_engine")
+
+
+def _create_pdf(path: Path, text: str) -> None:
+    doc = fitz.open()
+    doc.new_page().insert_text((72, 72), text)
+    doc.save(path)
+    doc.close()
+
+
+def test_process_single_pdf(tmp_path):
+    pdf = tmp_path / "sample.pdf"
+    _create_pdf(pdf, "Hello")
+    txt_dir = tmp_path / "txt"
+    txt_dir.mkdir()
+
+    progress = []
+    ocr_flags = []
+    event = threading.Event()
+
+    result = processing_engine.process_single_pdf(
+        pdf,
+        txt_dir,
+        progress.append,
+        ocr_flags.append,
+        event,
+    )
+
+    txt_file = txt_dir / "sample.txt"
+    assert txt_file.exists()
+    assert ocr_flags == [True, False]
+    assert progress == [f"Analyzing content of {pdf.name}..."]
+    assert result["file_name"] == "sample.pdf"
+    assert result["Meta"] == "ModelX"
+


### PR DESCRIPTION
## Summary
- add unit test for `process_single_pdf` using a generated PDF
- cover retry logic in `copy_file_safely`

## Testing
- `ruff check tests/test_processing_engine.py tests/test_file_utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a42e96580832eb5188065abad5979