### PR TITLE
Add tests and CI setup notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,15 +96,15 @@ This tool extracts model info, QA/SB numbers, and descriptions from Kyocera QA/s
 
 ### Install Dependencies
 If you plan to run or test the tool locally, first install the required Python
-packages with the helper script:
+packages with `pip`:
 
 ```bash
-cd KYO_QA_ServiceNow_Knowledge_Tool_v24.0.1
-./scripts/setup_env.sh
+pip install -r requirements.txt
 ```
 
-The test suite relies on these packages, so make sure to run the script before
-executing `pytest`.
+The unit tests need additional packages such as `openpyxl` (for reading the
+generated spreadsheets) and `PyMuPDF`. These are all listed in
+`requirements.txt`, so install them before running `pytest`.
 
 ### Development and Testing
 After installing the dependencies, run the test suite with:

--- a/tests/test_excel_generator.py
+++ b/tests/test_excel_generator.py
@@ -22,3 +22,24 @@ def test_generate_excel_no_template_returns_path(tmp_path):
     wb = openpyxl.load_workbook(out_file)
     sheet = wb.active
     assert sheet["A2"].alignment.wrap_text
+
+def test_apply_formatting_wrap_and_fill(tmp_path):
+    from openpyxl import Workbook
+    from excel_generator import _apply_formatting, REVIEW_FILL
+
+    wb = Workbook()
+    sheet = wb.active
+    sheet.append(["col1", "needs_review", "col3"])
+    sheet.append(["a", "TRUE", "c"])
+    sheet.append(["d", "", "f"])
+
+    _apply_formatting(sheet)
+
+    # Row with needs_review TRUE should have fill applied
+    for cell in sheet[2]:
+        assert cell.alignment.wrap_text
+        assert cell.fill.start_color.rgb == REVIEW_FILL.start_color.rgb
+    # Row without needs_review should not be filled
+    for cell in sheet[3]:
+        assert cell.alignment.wrap_text
+        assert cell.fill.start_color.rgb != REVIEW_FILL.start_color.rgb

--- a/tests/test_processing_engine.py
+++ b/tests/test_processing_engine.py
@@ -1,0 +1,56 @@
+import sys
+import types
+import threading
+from pathlib import Path
+
+# Create dummy extract.ai_extractor module so processing_engine can import it
+fake_extract = types.ModuleType("ai_extractor")
+class DummyQAExtractor:
+    def extract(self, text, path):
+        return {
+            "full_qa_number": "AAA-1234",
+            "short_qa_number": "A1234",
+            "models": "Model1",
+            "subject": "Test subject",
+            "published_date": "2024-01-01",
+            "author": "Tester",
+        }
+    def extract_qa_numbers(self, text):
+        return []
+    def extract_models(self, text):
+        return []
+    def extract_dates(self, text):
+        return []
+
+fake_extract.QAExtractor = DummyQAExtractor
+sys.modules['extract.ai_extractor'] = fake_extract
+
+import processing_engine
+
+
+def test_process_files_with_mock_pdfs(tmp_path, monkeypatch):
+    folder = tmp_path / "input"
+    folder.mkdir()
+    (folder / "a.pdf").write_bytes(b"dummy")
+    (folder / "b.pdf").write_bytes(b"dummy")
+
+    monkeypatch.setattr(processing_engine, "_is_ocr_needed", lambda p: False)
+    monkeypatch.setattr(processing_engine, "extract_text_from_pdf", lambda p: "text")
+    monkeypatch.setattr(processing_engine, "qa_extractor", DummyQAExtractor())
+    monkeypatch.setattr(processing_engine, "generate_excel", lambda data, out, tpl: str(out))
+    monkeypatch.setattr(processing_engine, "get_temp_dir", lambda: tmp_path / "temp")
+    monkeypatch.setattr(processing_engine, "cleanup_temp_files", lambda d: None)
+
+    progress_calls = []
+    progress_cb = lambda msg: progress_calls.append(msg)
+    ocr_cb = lambda state: None
+    cancel_event = threading.Event()
+
+    out_excel = tmp_path / "result.xlsx"
+    excel_path, review_list, failures = processing_engine.process_files(
+        folder, out_excel, None, progress_cb, ocr_cb, cancel_event
+    )
+
+    assert excel_path == str(out_excel)
+    assert review_list == []
+    assert failures == 0


### PR DESCRIPTION
## Summary
- clarify dependency installation for running tests
- test `process_files` using mocked PDFs
- verify `_apply_formatting` applies wrap text and conditional fill

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a42d8b724832eadbd032dd189fa69