### PR TITLE
Fix unused imports & add lint test

### DIFF
--- a/ocr_utils.py
+++ b/ocr_utils.py
@@ -13,8 +13,6 @@ def init_tesseract():
     try:
         # Try to import pytesseract
         import pytesseract
-        from PIL import Image
-        import io
         
         # Check common Windows paths
         tesseract_paths = [

--- a/processing_engine.py
+++ b/processing_engine.py
@@ -1,5 +1,4 @@
 # KYO QA ServiceNow Processing Engine - FINALIZED MODEL MAPPING
-import os
 import re
 import zipfile
 from pathlib import Path
@@ -7,15 +6,6 @@ import fitz
 from datetime import datetime, timedelta
 
 from logging_utils import setup_logger, log_info, log_error, log_warning
-# Import custom exceptions explicitly so linters know where they come from
-from custom_exceptions import (
-    QAExtractionError,
-    FileProcessingError,
-    ExcelGenerationError,
-    OCRError,
-    ZipExtractionError,
-    ConfigurationError,
-)
 from file_utils import get_temp_dir, cleanup_temp_files, is_pdf, is_zip, save_txt
 from ocr_utils import extract_text_from_pdf
 from extract.ai_extractor import QAExtractor

--- a/tests/test_import_cleanup.py
+++ b/tests/test_import_cleanup.py
@@ -1,0 +1,10 @@
+import subprocess
+
+
+def test_no_f401_warnings():
+    """Ensure flake8 does not report unused-import warnings."""
+    result = subprocess.run([
+        "flake8",
+        "--select=F401",
+    ], capture_output=True, text=True)
+    assert result.stdout.strip() == ""


### PR DESCRIPTION
## Summary
- remove leftover `Image` and `io` imports from `ocr_utils`
- clean up unused imports from `processing_engine`
- add test ensuring flake8 reports no unused imports

## Testing
- `flake8 | grep F401`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a42e45750832e9f2349ea3cfb048a