### PR TITLE
Optimize OCR pre-check

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This tool extracts model info, QA/SB numbers, and descriptions from Kyocera QA/s
 | File                  | Role                                               |
 |------------------------|----------------------------------------------------|
 | `kyo_qa_tool_app.py`   | Main controller and orchestrator                  |
-| `processing_engine.py` | Coordinates the multi-step processing pipeline    |
+| `processing_engine.py` | Coordinates the multi-step processing pipeline. Checks only the first page when deciding if OCR is needed |
 | `ocr_utils.py`         | Converts PDF scans to text using OCR              |
 | `ai_extractor.py`      | Extracts structured data using regex/NLP          |
 | `data_harvesters.py`   | Adds supplemental metadata (e.g., model names)    |

--- a/processing_engine.py
+++ b/processing_engine.py
@@ -26,12 +26,13 @@ logger = setup_logger("processing_engine")
 qa_extractor = QAExtractor()
 
 def _is_ocr_needed(pdf_path):
-    """Checks if a PDF contains very little text, suggesting it's image-based and needs OCR."""
+    """Checks the first page for text to determine if OCR is required."""
     try:
         with fitz.open(pdf_path) as doc:
-            if not doc.is_pdf or doc.is_encrypted:
+            if not doc.is_pdf or doc.is_encrypted or len(doc) == 0:
                 return False
-            text_content = "".join(page.get_text() for page in doc)
+            first_page = doc[0]
+            text_content = first_page.get_text()
             return len(text_content.strip()) < 100
     except Exception as e:
         log_warning(logger, f"Could not pre-check PDF {pdf_path.name}: {e}")

--- a/tests/test_processing_engine.py
+++ b/tests/test_processing_engine.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import types
+import fitz
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Stub out extract.ai_extractor to avoid heavy imports
+extract = types.ModuleType("extract")
+extract.ai_extractor = types.ModuleType("ai_extractor")
+extract.ai_extractor.QAExtractor = object
+sys.modules.setdefault("extract", extract)
+sys.modules.setdefault("extract.ai_extractor", extract.ai_extractor)
+
+from processing_engine import _is_ocr_needed
+
+def create_two_page_pdf(tmp_path: Path) -> Path:
+    doc = fitz.open()
+    doc.new_page()  # first page blank
+    page2 = doc.new_page()
+    page2.insert_text((72, 72), "Text on page 2")
+    pdf_path = tmp_path / "sample.pdf"
+    doc.save(pdf_path)
+    doc.close()
+    return pdf_path
+
+def test_is_ocr_needed_first_page_only(tmp_path):
+    pdf_file = create_two_page_pdf(tmp_path)
+    assert _is_ocr_needed(pdf_file)


### PR DESCRIPTION
## Summary
- speed up `_is_ocr_needed` by reading only the first page of a PDF
- document this new behavior
- add a unit test covering the single-page OCR check

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a42e5dfd8832eacf4f4301f182240