### PR TITLE
Cleanup imports and format code

### DIFF
--- a/ocr_utils.py
+++ b/ocr_utils.py
@@ -7,47 +7,54 @@ from logging_utils import setup_logger, log_info, log_error, log_warning
 
 logger = setup_logger("ocr_utils")
 
+
 # Check if tesseract is available and set path if needed
 def init_tesseract():
     """Initialize Tesseract OCR if available."""
     try:
         # Try to import pytesseract
         import pytesseract
-        from PIL import Image
-        import io
-        
+
         # Check common Windows paths
         tesseract_paths = [
             r"C:\Program Files\Tesseract-OCR\tesseract.exe",
             r"C:\Program Files (x86)\Tesseract-OCR\tesseract.exe",
         ]
-        
+
         for path in tesseract_paths:
             if os.path.exists(path):
                 pytesseract.pytesseract.tesseract_cmd = path
                 log_info(logger, f"Tesseract found at: {path}")
                 return True
-                
+
         # Try to run tesseract directly (Linux/Mac)
         try:
             output = os.popen("tesseract --version").read()
             if "tesseract" in output.lower():
                 log_info(logger, "Tesseract found in system PATH")
                 return True
-        except:
+        except Exception:
             pass
-            
-        log_warning(logger, "Tesseract OCR not found. Image-based OCR will be disabled.")
+
+        log_warning(
+            logger,
+            "Tesseract OCR not found. Image-based OCR will be disabled."
+        )
         return False
     except ImportError:
-        log_warning(logger, "pytesseract not installed. Image-based OCR will be disabled.")
+        log_warning(
+            logger,
+            "pytesseract not installed. Image-based OCR will be disabled."
+        )
         return False
     except Exception as e:
         log_error(logger, f"Error initializing Tesseract: {e}")
         return False
 
+
 # Initialize on module load
 TESSERACT_AVAILABLE = init_tesseract()
+
 
 def extract_text_from_pdf(pdf_path: Path | str) -> str:
     """Extract text from a PDF file, using OCR if needed."""
@@ -58,26 +65,45 @@ def extract_text_from_pdf(pdf_path: Path | str) -> str:
         # First try standard text extraction
         with fitz.open(pdf_path) as doc:
             text = "".join(page.get_text() for page in doc)
-            
+
         # If we got meaningful text, return it
         if text and len(text.strip()) > 50:
             log_info(logger, f"Extracted text directly from {pdf_path.name}")
-            log_info(logger, f"Finished text extraction for {pdf_path.name} - {len(text)} chars")
+            log_info(
+                logger,
+                "Finished text extraction for "
+                f"{pdf_path.name} - {len(text)} chars"
+            )
             return text
-            
+
         # If text extraction failed and Tesseract is available, try OCR
         if TESSERACT_AVAILABLE:
             log_info(logger, f"Attempting OCR on {pdf_path.name}")
             ocr_text = extract_text_with_ocr(pdf_path)
-            log_info(logger, f"Finished text extraction for {pdf_path.name} - {len(ocr_text)} chars")
+            log_info(
+                logger,
+                "Finished text extraction for "
+                f"{pdf_path.name} - {len(ocr_text)} chars"
+            )
             return ocr_text
         else:
-            log_warning(logger, f"No text found in {pdf_path.name} and OCR not available")
-            log_info(logger, f"Finished text extraction for {pdf_path.name} - {len(text)} chars")
+            log_warning(
+                logger,
+                f"No text found in {pdf_path.name} and OCR not available"
+            )
+            log_info(
+                logger,
+                "Finished text extraction for "
+                f"{pdf_path.name} - {len(text)} chars"
+            )
             return text
     except Exception as exc:
-        log_error(logger, f"Failed to extract text from {pdf_path.name}: {exc}")
+        log_error(
+            logger,
+            f"Failed to extract text from {pdf_path.name}: {exc}"
+        )
         return ""
+
 
 def extract_text_with_ocr(pdf_path: Path | str) -> str:
     """Extract text from PDF using OCR on rendered images."""
@@ -91,26 +117,33 @@ def extract_text_with_ocr(pdf_path: Path | str) -> str:
         import pytesseract
         from PIL import Image
         import io
-        
+
         all_text = []
         with fitz.open(pdf_path) as doc:
             for page_num, page in enumerate(doc):
                 # Render page to image at higher resolution for better OCR
                 pix = page.get_pixmap(matrix=fitz.Matrix(2, 2))
                 img = Image.open(io.BytesIO(pix.tobytes("png")))
-                
+
                 # Use pytesseract to extract text
                 page_text = pytesseract.image_to_string(img)
                 all_text.append(page_text)
-                
-                log_info(logger, f"OCR processed page {page_num+1} of {pdf_path}")
-                
+
+                log_info(
+                    logger,
+                    f"OCR processed page {page_num+1} of {pdf_path}"
+                )
+
         result = "\n\n".join(all_text)
-        log_info(logger, f"OCR extraction complete for {pdf_path}: {len(result)} chars")
+        log_info(
+            logger,
+            f"OCR extraction complete for {pdf_path}: {len(result)} chars"
+        )
         return result
     except Exception as e:
         log_error(logger, f"OCR extraction failed for {pdf_path}: {e}")
         return ""
+
 
 def get_pdf_metadata(pdf_path: Path | str) -> dict:
     """Extract metadata from a PDF file."""
@@ -118,7 +151,7 @@ def get_pdf_metadata(pdf_path: Path | str) -> dict:
         with fitz.open(pdf_path) as doc:
             metadata = doc.metadata
             page_count = len(doc)
-            
+
         result = {
             "title": metadata.get("title", ""),
             "author": metadata.get("author", ""),
@@ -130,7 +163,7 @@ def get_pdf_metadata(pdf_path: Path | str) -> dict:
             "modDate": metadata.get("modDate", ""),
             "page_count": page_count
         }
-        
+
         log_info(logger, f"Extracted metadata from {pdf_path}")
         return result
     except Exception as e:

--- a/processing_engine.py
+++ b/processing_engine.py
@@ -1,5 +1,4 @@
 # KYO QA ServiceNow Processing Engine - FINALIZED MODEL MAPPING
-import os
 import re
 import zipfile
 from pathlib import Path
@@ -7,16 +6,14 @@ import fitz
 from datetime import datetime, timedelta
 
 from logging_utils import setup_logger, log_info, log_error, log_warning
-# Import custom exceptions explicitly so linters know where they come from
-from custom_exceptions import (
-    QAExtractionError,
-    FileProcessingError,
-    ExcelGenerationError,
-    OCRError,
-    ZipExtractionError,
-    ConfigurationError,
+
+from file_utils import (
+    get_temp_dir,
+    cleanup_temp_files,
+    is_pdf,
+    is_zip,
+    save_txt,
 )
-from file_utils import get_temp_dir, cleanup_temp_files, is_pdf, is_zip, save_txt
 from ocr_utils import extract_text_from_pdf
 from extract.ai_extractor import QAExtractor
 from excel_generator import generate_excel
@@ -25,8 +22,10 @@ from config import STANDARDIZATION_RULES
 logger = setup_logger("processing_engine")
 qa_extractor = QAExtractor()
 
+
 def _is_ocr_needed(pdf_path):
-    """Checks if a PDF contains very little text, suggesting it's image-based and needs OCR."""
+    """Checks if a PDF contains very little text."""
+    """Suggests it's image-based and needs OCR."""
     try:
         with fitz.open(pdf_path) as doc:
             if not doc.is_pdf or doc.is_encrypted:
@@ -37,11 +36,18 @@ def _is_ocr_needed(pdf_path):
         log_warning(logger, f"Could not pre-check PDF {pdf_path.name}: {e}")
         return True
 
-def process_single_pdf(pdf_path, txt_output_dir, progress_cb, ocr_cb, cancel_event):
+
+def process_single_pdf(
+    pdf_path,
+    txt_output_dir,
+    progress_cb,
+    ocr_cb,
+    cancel_event,
+):
     """Processes a single PDF file and returns structured data."""
-    if cancel_event.is_set(): 
+    if cancel_event.is_set():
         return None
-        
+
     filename = Path(pdf_path).name
     log_info(logger, f"Processing PDF: {filename}")
 
@@ -49,15 +55,18 @@ def process_single_pdf(pdf_path, txt_output_dir, progress_cb, ocr_cb, cancel_eve
     if _is_ocr_needed(pdf_path):
         ocr_cb(True)
         log_info(logger, f"OCR required for {filename}.")
-    
+
     extracted_text = extract_text_from_pdf(pdf_path)
     ocr_cb(False)
-    
-    if cancel_event.is_set(): 
+
+    if cancel_event.is_set():
         return None
 
     if not extracted_text:
-        log_warning(logger, f"No text could be extracted from {filename}. Skipping.")
+        log_warning(
+            logger,
+            f"No text could be extracted from {filename}. Skipping."
+        )
         return create_error_record(filename, "TEXT EXTRACTION FAILED")
 
     # Save extracted text for debugging
@@ -68,11 +77,17 @@ def process_single_pdf(pdf_path, txt_output_dir, progress_cb, ocr_cb, cancel_eve
 
     # Extract data using AI extractor
     extracted_data = qa_extractor.extract(extracted_text, Path(pdf_path))
-    
+
     # Log what we extracted for debugging
     log_info(logger, f"Raw extracted data for {filename}:")
-    log_info(logger, f"  Full QA: '{extracted_data.get('full_qa_number', '')}'")
-    log_info(logger, f"  Short QA: '{extracted_data.get('short_qa_number', '')}'") 
+    log_info(
+        logger,
+        f"  Full QA: '{extracted_data.get('full_qa_number', '')}'"
+    )
+    log_info(
+        logger,
+        f"  Short QA: '{extracted_data.get('short_qa_number', '')}'"
+    )
     log_info(logger, f"  Models: '{extracted_data.get('models', '')}'")
     log_info(logger, f"  Subject: '{extracted_data.get('subject', '')}'")
 
@@ -83,6 +98,7 @@ def process_single_pdf(pdf_path, txt_output_dir, progress_cb, ocr_cb, cancel_eve
     servicenow_record = map_to_servicenow_format(validated_data, filename)
 
     return servicenow_record
+
 
 def create_error_record(filename, error_msg):
     """Create a standardized error record."""
@@ -96,14 +112,14 @@ def create_error_record(filename, error_msg):
         "Description": filename,
         "Attachment link": "",
         "Disable commenting": "FALSE",
-        "Disable suggesting": "FALSE", 
+        "Disable suggesting": "FALSE",
         "Display attachments": "FALSE",
         "Flagged": "FALSE",
         "Governance": "Compliance Based",
         "Category(kb_category)": "",
         "Knowledge base": "Tech QA",
         "Meta": "ERROR",
-        "Meta Description": "ERROR", 
+        "Meta Description": "ERROR",
         "Ownership Group": "",
         "Published": "",
         "Scheduled publish date": "",
@@ -111,7 +127,7 @@ def create_error_record(filename, error_msg):
         "Article body": "",
         "Topic": "General",
         "Problem Code": "",
-        "models": error_msg, 
+        "models": error_msg,
         "Ticket#": "",
         "Valid to": "2036-03-04",
         "View as allowed": "TRUE",
@@ -122,15 +138,23 @@ def create_error_record(filename, error_msg):
         "needs_review": True
     }
 
+
 def validate_and_enhance_data(extracted_data, filename):
     """Validate and enhance the extracted data."""
-    
+
     # Ensure all required fields exist
-    required_fields = ["full_qa_number", "short_qa_number", "models", "subject", "published_date", "author"]
+    required_fields = [
+        "full_qa_number",
+        "short_qa_number",
+        "models",
+        "subject",
+        "published_date",
+        "author",
+    ]
     for field in required_fields:
         if field not in extracted_data:
             extracted_data[field] = ""
-    
+
     # Clean up QA numbers
     if extracted_data["full_qa_number"]:
         qa_clean = extracted_data["full_qa_number"].strip()
@@ -142,23 +166,28 @@ def validate_and_enhance_data(extracted_data, filename):
                 # Insert dash if missing (e.g., 2ND0148 -> 2ND-0148)
                 qa_clean = qa_clean[:3] + '-' + qa_clean[3:]
         extracted_data["full_qa_number"] = qa_clean
-    
+
     # Clean up short QA number
     if extracted_data["short_qa_number"]:
         short_clean = extracted_data["short_qa_number"].strip()
         short_clean = re.sub(r'[^\w]', '', short_clean)
         extracted_data["short_qa_number"] = short_clean
-    
+
     # Validate date format
     if extracted_data["published_date"]:
         try:
             # Ensure YYYY-MM-DD format
-            date_obj = datetime.strptime(extracted_data["published_date"], "%Y-%m-%d")
+            date_obj = datetime.strptime(
+                extracted_data["published_date"], "%Y-%m-%d"
+            )
             extracted_data["published_date"] = date_obj.strftime("%Y-%m-%d")
         except ValueError:
-            log_warning(logger, f"Invalid date format: {extracted_data['published_date']}")
+            log_warning(
+                logger,
+                f"Invalid date format: {extracted_data['published_date']}"
+            )
             extracted_data["published_date"] = ""
-    
+
     # Clean up models
     if extracted_data["models"] and extracted_data["models"] != "Not Found":
         models_clean = extracted_data["models"].strip()
@@ -168,93 +197,141 @@ def validate_and_enhance_data(extracted_data, filename):
         # Remove any trailing punctuation
         models_clean = models_clean.rstrip('.,;')
         extracted_data["models"] = models_clean
-        
+
         log_info(logger, f"Cleaned models for {filename}: '{models_clean}'")
     else:
         log_warning(logger, f"No models found for {filename}")
-    
+
     # Clean up subject
     if extracted_data["subject"] and extracted_data["subject"] != "Not Found":
         subject_clean = extracted_data["subject"].strip()
         # Remove redundant information
         if extracted_data["full_qa_number"]:
-            subject_clean = subject_clean.replace(extracted_data["full_qa_number"], "").strip()
+            subject_clean = subject_clean.replace(
+                extracted_data["full_qa_number"], ""
+            ).strip()
         if extracted_data["short_qa_number"]:
-            subject_clean = subject_clean.replace(f"({extracted_data['short_qa_number']})", "").strip()
+            subject_clean = subject_clean.replace(
+                f"({extracted_data['short_qa_number']})",
+                ""
+            ).strip()
         subject_clean = re.sub(r'\s+', ' ', subject_clean).strip(' ,-')
         extracted_data["subject"] = subject_clean
-    
+
     return extracted_data
+
 
 def map_to_servicenow_format(extracted_data, filename):
     """Map extracted data to ServiceNow import format - FIXED VERSION."""
-    
+
     # Determine if this record needs review
     needs_review = False
     review_reasons = []
-    
+
     if not extracted_data.get("full_qa_number"):
         needs_review = True
         review_reasons.append("Missing QA Number")
-    
-    if not extracted_data.get("models") or extracted_data["models"] in ["Not Found", ""]:
+
+    if (
+        not extracted_data.get("models")
+        or extracted_data["models"] in ["Not Found", ""]
+    ):
         needs_review = True
         review_reasons.append("Missing Models")
-    
-    if not extracted_data.get("subject") or extracted_data["subject"] in ["Not Found", ""]:
+
+    if (
+        not extracted_data.get("subject")
+        or extracted_data["subject"] in ["Not Found", ""]
+    ):
         needs_review = True
         review_reasons.append("Missing Subject")
-    
+
     if needs_review:
-        log_warning(logger, f"Flagging '{filename}' for review: {', '.join(review_reasons)}")
-    
+        log_warning(
+            logger,
+            f"Flagging '{filename}' for review: {', '.join(review_reasons)}"
+        )
+
     # Build short description
     short_desc_parts = []
-    
-    if extracted_data.get("full_qa_number") and extracted_data.get("short_qa_number"):
-        short_desc_parts.append(f"{extracted_data['full_qa_number']}({extracted_data['short_qa_number']})")
-    
+
+    if (
+        extracted_data.get("full_qa_number")
+        and extracted_data.get("short_qa_number")
+    ):
+        short_desc_parts.append(
+            f"{extracted_data['full_qa_number']}("
+            f"{extracted_data['short_qa_number']})"
+        )
+
     if extracted_data.get("published_date"):
         try:
-            pub_date_obj = datetime.strptime(extracted_data["published_date"], "%Y-%m-%d")
-            short_desc_parts.append(f"<Date> {pub_date_obj.strftime('%B %d, %Y')}")
+            pub_date_obj = datetime.strptime(
+                extracted_data["published_date"], "%Y-%m-%d"
+            )
+            short_desc_parts.append(
+                f"<Date> {pub_date_obj.strftime('%B %d, %Y')}"
+            )
         except (ValueError, TypeError):
             if extracted_data["published_date"]:
-                short_desc_parts.append(f"<Date> {extracted_data['published_date']}")
-    
-    if extracted_data.get("subject") and extracted_data["subject"] not in ["Not Found", ""]:
+                short_desc_parts.append(
+                    f"<Date> {extracted_data['published_date']}"
+                )
+
+    if (
+        extracted_data.get("subject")
+        and extracted_data["subject"] not in ["Not Found", ""]
+    ):
         short_desc_parts.append(extracted_data["subject"])
-    
-    short_description = " - ".join(short_desc_parts) if short_desc_parts else filename
-    
+
+    short_description = (
+        " - ".join(short_desc_parts) if short_desc_parts else filename
+    )
+
     # Calculate valid to date (12 years from publish date)
     valid_to_date = "2036-03-04"  # Default fallback
     if extracted_data.get("published_date"):
         try:
-            pub_date = datetime.strptime(extracted_data["published_date"], "%Y-%m-%d")
-            valid_to_date = (pub_date + timedelta(days=12*365)).strftime("%Y-%m-%d")
+            pub_date = datetime.strptime(
+                extracted_data["published_date"], "%Y-%m-%d"
+            )
+            valid_to_date = (
+                pub_date + timedelta(days=12 * 365)
+            ).strftime("%Y-%m-%d")
         except (ValueError, TypeError):
             pass
-    
+
     # Get models data for 'Meta' and 'models' fields
     models_data = ""
-    if extracted_data.get("models") and extracted_data["models"] not in ["Not Found", ""]:
+    if (
+        extracted_data.get("models")
+        and extracted_data["models"] not in ["Not Found", ""]
+    ):
         models_data = extracted_data["models"]
-        log_info(logger, f"Setting models data for {filename}: '{models_data}'")
+        log_info(
+            logger,
+            f"Setting models data for {filename}: '{models_data}'"
+        )
     else:
-        log_warning(logger, f"No models data to set for {filename}")
-        
+        log_warning(
+            logger,
+            f"No models data to set for {filename}"
+        )
+
     # Build the 'Meta Description' field from the short QA number
     meta_description_data = "QA"
     if extracted_data.get("short_qa_number"):
         meta_description_data = f"QA, {extracted_data.get('short_qa_number')}"
-    
+
     # Create the ServiceNow record with proper data types
     servicenow_record = {
         "Active": "TRUE",
         "Article type": extracted_data.get("document_type", "HTML"),
-        "Author": extracted_data.get("author", STANDARDIZATION_RULES["default_author"]),
-        "Category(category)": "Dealer", 
+        "Author": extracted_data.get(
+            "author",
+            STANDARDIZATION_RULES["default_author"],
+        ),
+        "Category(category)": "Dealer",
         "Configuration item": "",
         "Confidence": "Validated",
         "Description": filename,
@@ -266,8 +343,10 @@ def map_to_servicenow_format(extracted_data, filename):
         "Governance": "Compliance Based",
         "Category(kb_category)": "",
         "Knowledge base": "Tech QA",
-        "Meta": models_data if models_data else "QA",  # FINAL FIX: Models go here
-        "Meta Description": meta_description_data, # FINAL FIX: "QA, E014" goes here
+        "Meta": models_data if models_data else "QA",
+        # FINAL FIX: Models go here
+        "Meta Description": meta_description_data,
+        # FINAL FIX: "QA, E014" goes here
         "Ownership Group": "",
         "Published": extracted_data.get("published_date", ""),
         "Scheduled publish date": "",
@@ -275,7 +354,7 @@ def map_to_servicenow_format(extracted_data, filename):
         "Article body": "",  # Keep empty as per template
         "Topic": "General",
         "Problem Code": "",
-        "models": models_data, # Keep a dedicated 'models' field as well
+        "models": models_data,  # Keep a dedicated 'models' field as well
         "Ticket#": "",
         "Valid to": valid_to_date,
         "View as allowed": "TRUE",
@@ -285,46 +364,76 @@ def map_to_servicenow_format(extracted_data, filename):
         "file_name": filename,
         "needs_review": needs_review
     }
-    
+
     # Log the final mapping for debugging
     log_info(logger, f"Final ServiceNow record for {filename}:")
-    log_info(logger, f"  Meta: '{servicenow_record['Meta']}'") 
-    log_info(logger, f"  Meta Description: '{servicenow_record['Meta Description']}'")
-    log_info(logger, f"  models: '{servicenow_record['models']}'")
-    log_info(logger, f"  Short description: '{servicenow_record['Short description'][:100]}...'")
-    
+    log_info(
+        logger,
+        f"  Meta: '{servicenow_record['Meta']}'"
+    )
+    log_info(
+        logger,
+        f"  Meta Description: '{servicenow_record['Meta Description']}'"
+    )
+    log_info(
+        logger,
+        f"  models: '{servicenow_record['models']}'"
+    )
+    log_info(
+        logger,
+        "  Short description: '"
+        f"{servicenow_record['Short description'][:100]}...'"
+    )
+
     return servicenow_record
 
-def process_zip_file(zip_path, temp_dir, txt_output_dir, progress_cb, ocr_cb, cancel_event):
+
+def process_zip_file(
+    zip_path,
+    temp_dir,
+    txt_output_dir,
+    progress_cb,
+    ocr_cb,
+    cancel_event,
+):
     """Extracts all PDFs from a ZIP file and processes them individually."""
-    if cancel_event.is_set(): 
+    if cancel_event.is_set():
         return []
-        
+
     log_info(logger, f"Processing ZIP file: {zip_path.name}")
     results = []
-    
+
     try:
         with zipfile.ZipFile(zip_path, 'r') as zip_ref:
-            pdf_files_in_zip = [f for f in zip_ref.namelist() 
-                              if is_pdf(f) and not f.startswith('__MACOSX')]
-            
+            pdf_files_in_zip = [
+                f
+                for f in zip_ref.namelist()
+                if is_pdf(f) and not f.startswith("__MACOSX")
+            ]
+
             if not pdf_files_in_zip:
                 log_warning(logger, f"No PDF files found in {zip_path.name}.")
                 return []
-            
+
             extraction_path = temp_dir / zip_path.stem
             zip_ref.extractall(extraction_path)
-            
+
             for pdf_file in pdf_files_in_zip:
-                if cancel_event.is_set(): 
+                if cancel_event.is_set():
                     break
                 full_pdf_path = extraction_path / pdf_file
-                result = process_single_pdf(full_pdf_path, txt_output_dir, progress_cb, ocr_cb, cancel_event)
-                if result: 
+                result = process_single_pdf(
+                    full_pdf_path,
+                    txt_output_dir,
+                    progress_cb,
+                    ocr_cb,
+                    cancel_event,
+                )
+                if result:
                     results.append(result)
-                    
+
         return results
-        
+
     except zipfile.BadZipFile:
         log_error(logger, f"File is not a valid ZIP file: {zip_path.name}")
         return []
@@ -332,73 +441,160 @@ def process_zip_file(zip_path, temp_dir, txt_output_dir, progress_cb, ocr_cb, ca
         log_error(logger, f"Failed to process ZIP file {zip_path.name}: {e}")
         return []
 
-def _process_file_list(file_list, temp_dir, txt_output_dir, progress_cb, ocr_cb, cancel_event):
+
+def _process_file_list(
+    file_list,
+    temp_dir,
+    txt_output_dir,
+    progress_cb,
+    ocr_cb,
+    cancel_event,
+):
     """Helper function to iterate through a list of files and process them."""
     all_results, failed_files = [], []
     total_files = len(file_list)
 
     for i, file_path in enumerate(file_list):
         if cancel_event.is_set():
-            log_warning(logger, "Cancellation signal received. Stopping process.")
+            log_warning(
+                logger,
+                "Cancellation signal received. Stopping process."
+            )
             break
-        
+
         progress_cb(f"Processing file {i+1}/{total_files}: {file_path.name}")
-        
+
         try:
             if is_pdf(file_path):
-                result = process_single_pdf(file_path, txt_output_dir, progress_cb, ocr_cb, cancel_event)
-                if result: 
+                result = process_single_pdf(
+                    file_path,
+                    txt_output_dir,
+                    progress_cb,
+                    ocr_cb,
+                    cancel_event,
+                )
+                if result:
                     all_results.append(result)
             elif is_zip(file_path):
-                results = process_zip_file(file_path, temp_dir, txt_output_dir, progress_cb, ocr_cb, cancel_event)
+                results = process_zip_file(
+                    file_path,
+                    temp_dir,
+                    txt_output_dir,
+                    progress_cb,
+                    ocr_cb,
+                    cancel_event,
+                )
                 all_results.extend(results)
         except Exception as e:
-            log_error(logger, f"Critical error processing file {file_path.name}: {e}")
+            log_error(
+                logger,
+                f"Critical error processing file {file_path.name}: {e}"
+            )
             failed_files.append(file_path.name)
 
     return all_results, failed_files
 
-def process_files(folder, excel_path, template_path, progress_cb, ocr_cb, cancel_event):
+
+def process_files(
+    folder,
+    excel_path,
+    template_path,
+    progress_cb,
+    ocr_cb,
+    cancel_event,
+):
     """Main entry point to process all PDF and ZIP files in a given folder."""
     source_folder = Path(folder)
     temp_dir = get_temp_dir()
     txt_output_dir = Path.cwd() / "PDF_TXT"
     txt_output_dir.mkdir(exist_ok=True)
-    
-    files_to_process = [f for f in source_folder.iterdir() if is_pdf(f) or is_zip(f)]
+
+    files_to_process = [
+        f for f in source_folder.iterdir() if is_pdf(f) or is_zip(f)
+    ]
     log_info(logger, f"Found {len(files_to_process)} files to process")
 
-    all_results, failed_files = _process_file_list(files_to_process, temp_dir, txt_output_dir, progress_cb, ocr_cb, cancel_event)
+    all_results, failed_files = _process_file_list(
+        files_to_process,
+        temp_dir,
+        txt_output_dir,
+        progress_cb,
+        ocr_cb,
+        cancel_event,
+    )
 
     cleanup_temp_files(temp_dir)
 
     final_excel_path = None
     if all_results and not cancel_event.is_set():
-        log_info(logger, f"Generating Excel file for {len(all_results)} processed documents.")
-        final_excel_path = generate_excel(all_results, excel_path, template_path)
+        log_info(
+            logger,
+            "Generating Excel file for "
+            f"{len(all_results)} processed documents."
+        )
+        final_excel_path = generate_excel(
+            all_results,
+            excel_path,
+            template_path,
+        )
     else:
-        log_warning(logger, "No data processed or process was cancelled. Excel file not generated.")
+        log_warning(
+            logger,
+            "No data processed or process was cancelled. "
+            "Excel file not generated."
+        )
 
-    review_list = [r["file_name"] for r in all_results if r.get("needs_review")]
+    review_list = [
+        r["file_name"] for r in all_results if r.get("needs_review")
+    ]
     return final_excel_path, review_list, len(failed_files)
 
-def process_pdf_list(pdf_paths, excel_path, template_path, progress_cb, ocr_cb, cancel_event):
+
+def process_pdf_list(
+    pdf_paths,
+    excel_path,
+    template_path,
+    progress_cb,
+    ocr_cb,
+    cancel_event,
+):
     """Main entry point to process a specific list of PDF files."""
     temp_dir = get_temp_dir()
     txt_output_dir = Path.cwd() / "PDF_TXT"
     txt_output_dir.mkdir(exist_ok=True)
-    
+
     files_to_process = [Path(p) for p in pdf_paths]
     log_info(logger, f"Processing {len(files_to_process)} individual files")
 
-    all_results, failed_files = _process_file_list(files_to_process, temp_dir, txt_output_dir, progress_cb, ocr_cb, cancel_event)
+    all_results, failed_files = _process_file_list(
+        files_to_process,
+        temp_dir,
+        txt_output_dir,
+        progress_cb,
+        ocr_cb,
+        cancel_event,
+    )
 
     final_excel_path = None
     if all_results and not cancel_event.is_set():
-        log_info(logger, f"Generating Excel file for {len(all_results)} processed documents.")
-        final_excel_path = generate_excel(all_results, excel_path, template_path)
+        log_info(
+            logger,
+            "Generating Excel file for "
+            f"{len(all_results)} processed documents."
+        )
+        final_excel_path = generate_excel(
+            all_results,
+            excel_path,
+            template_path,
+        )
     else:
-        log_warning(logger, "No data processed or process was cancelled. Excel file not generated.")
+        log_warning(
+            logger,
+            "No data processed or process was cancelled. "
+            "Excel file not generated."
+        )
 
-    review_list = [r["file_name"] for r in all_results if r.get("needs_review")]
+    review_list = [
+        r["file_name"] for r in all_results if r.get("needs_review")
+    ]
     return final_excel_path, review_list, len(failed_files)

--- a/tests/test_processing_engine.py
+++ b/tests/test_processing_engine.py
@@ -1,0 +1,27 @@
+import sys
+import types
+import fitz
+from pathlib import Path
+
+extract_module = types.ModuleType("extract.ai_extractor")
+class DummyExtractor:
+    def extract(self, text, path):
+        return {}
+extract_module.QAExtractor = DummyExtractor
+sys.modules['extract'] = types.ModuleType('extract')
+sys.modules['extract.ai_extractor'] = extract_module
+
+from processing_engine import _is_ocr_needed
+
+
+def test_is_ocr_needed_returns_false(tmp_path):
+    pdf_path = tmp_path / "sample.pdf"
+    doc = fitz.open()
+    page = doc.new_page()
+    text = "A" * 500
+    for i in range(4):
+        page.insert_text((72, 72 + i * 28), text)
+    doc.save(pdf_path)
+    doc.close()
+
+    assert _is_ocr_needed(pdf_path) is False


### PR DESCRIPTION
## Summary
- remove unused imports from `ocr_utils` and `processing_engine`
- wrap long lines and ensure two blank lines before functions
- convert files to Unix line endings and trim whitespace
- add unit test for `_is_ocr_needed`

## Testing
- `flake8 ocr_utils.py processing_engine.py | head`
- `flake8 | head -n 20`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a42d491f4832eb984c33f226be6b1