### PR TITLE
Fix bare excepts and clean imports

### DIFF
--- a/excel_generator.py
+++ b/excel_generator.py
@@ -1,5 +1,7 @@
 # KYO QA ServiceNow Excel Generator v24.0.6
-import pandas as pd, shutil, openpyxl
+import pandas as pd
+import shutil
+import openpyxl
 from openpyxl.utils.dataframe import dataframe_to_rows
 from openpyxl.styles import Alignment, PatternFill
 from logging_utils import setup_logger, log_info, log_error, log_warning
@@ -66,7 +68,9 @@ def _create_new_excel(df, output_path):
 
 def generate_excel(all_results, output_path, template_path):
     try:
-        if not all_results: raise ExcelGenerationError("No data to generate.")
+        if not all_results:
+            raise ExcelGenerationError("No data to generate.")
+
         df = pd.DataFrame(all_results)
         
         if template_path:

--- a/kyo_qa_tool_app.py
+++ b/kyo_qa_tool_app.py
@@ -190,7 +190,7 @@ class SafeColorSpinnerCanvas(tk.Canvas):
         if self._after_id:
             try:
                 self.after_cancel(self._after_id)
-            except:
+            except Exception:
                 pass
             self._after_id = None
 
@@ -381,7 +381,7 @@ class KyoQAToolApp(tk.Tk):
             try:
                 self.attributes("-fullscreen", True)
                 self.fullscreen = True
-            except:
+            except Exception:
                 self.state('zoomed')
                 self.fullscreen = False
             
@@ -391,7 +391,7 @@ class KyoQAToolApp(tk.Tk):
                 icon_path = base_path / "kyo_icon.ico"
                 if icon_path.exists():
                     self.iconbitmap(icon_path)
-            except:
+            except Exception:
                 pass  # Continue without icon
                 
         except Exception as e:
@@ -589,11 +589,19 @@ class KyoQAToolApp(tk.Tk):
             
             # Configure text tags for colors
             try:
-                self.log_text.tag_configure("success", foreground=BRAND_COLORS["success"])
-                self.log_text.tag_configure("warning", foreground=BRAND_COLORS["warning"])
-                self.log_text.tag_configure("error", foreground=BRAND_COLORS["error"])
-                self.log_text.tag_configure("info", foreground=BRAND_COLORS["info"])
-            except:
+                self.log_text.tag_configure(
+                    "success", foreground=BRAND_COLORS["success"]
+                )
+                self.log_text.tag_configure(
+                    "warning", foreground=BRAND_COLORS["warning"]
+                )
+                self.log_text.tag_configure(
+                    "error", foreground=BRAND_COLORS["error"]
+                )
+                self.log_text.tag_configure(
+                    "info", foreground=BRAND_COLORS["info"]
+                )
+            except Exception:
                 pass  # Continue without colored tags
                 
         except Exception as e:
@@ -684,7 +692,7 @@ class KyoQAToolApp(tk.Tk):
                     self.state('normal')
                 else:
                     self.state('zoomed')
-            except:
+            except Exception:
                 pass
 
     def on_closing(self):
@@ -849,14 +857,14 @@ class KyoQAToolApp(tk.Tk):
                     if match and hasattr(self, 'progress_frame'):
                         current, total = int(match.group(1)), int(match.group(2))
                         self.after(0, lambda: self.progress_frame.update_progress(current, total, msg))
-                except:
+                except Exception:
                     pass
 
             def ocr_cb(is_active):
                 try:
                     if hasattr(self, 'progress_frame'):
                         self.after(0, lambda: self.progress_frame.set_ocr_active(is_active))
-                except:
+                except Exception:
                     pass
 
             # Process files
@@ -867,7 +875,7 @@ class KyoQAToolApp(tk.Tk):
                                    if f.lower().endswith((".pdf", ".zip")))
                     if hasattr(self, 'progress_frame'):
                         self.after(0, lambda: self.progress_frame.show(file_count))
-                except:
+                except Exception:
                     file_count = 0
                 
                 self.result_file, review_files, fail_count = process_files(
@@ -937,7 +945,7 @@ def create_splash_screen():
             grad_frame = SafeGradientFrame(splash, 
                 BRAND_COLORS["secondary_purple"], BRAND_COLORS["header_bg"])
             grad_frame.pack(fill="both", expand=True)
-        except:
+        except Exception:
             # Fallback to solid color
             grad_frame = tk.Frame(splash, bg=BRAND_COLORS["header_bg"])
             grad_frame.pack(fill="both", expand=True)
@@ -965,9 +973,9 @@ def create_splash_screen():
             spinner = SafeColorSpinnerCanvas(content_frame, width=80, height=80, 
                                            bg=grad_frame.cget("bg"))
             spinner.pack(pady=20)
-        except:
+        except Exception:
             # Fallback to simple label
-            spinner = tk.Label(content_frame, text="Loading...", 
+            spinner = tk.Label(content_frame, text="Loading...",
                              bg=grad_frame.cget("bg"), fg=BRAND_COLORS["header_fg"])
             spinner.pack(pady=20)
         

--- a/ocr_utils.py
+++ b/ocr_utils.py
@@ -13,8 +13,6 @@ def init_tesseract():
     try:
         # Try to import pytesseract
         import pytesseract
-        from PIL import Image
-        import io
         
         # Check common Windows paths
         tesseract_paths = [
@@ -34,7 +32,7 @@ def init_tesseract():
             if "tesseract" in output.lower():
                 log_info(logger, "Tesseract found in system PATH")
                 return True
-        except:
+        except Exception:
             pass
             
         log_warning(logger, "Tesseract OCR not found. Image-based OCR will be disabled.")
@@ -91,7 +89,7 @@ def extract_text_with_ocr(pdf_path: Path | str) -> str:
         import pytesseract
         from PIL import Image
         import io
-        
+
         all_text = []
         with fitz.open(pdf_path) as doc:
             for page_num, page in enumerate(doc):

--- a/processing_engine.py
+++ b/processing_engine.py
@@ -1,5 +1,4 @@
 # KYO QA ServiceNow Processing Engine - FINALIZED MODEL MAPPING
-import os
 import re
 import zipfile
 from pathlib import Path
@@ -8,14 +7,6 @@ from datetime import datetime, timedelta
 
 from logging_utils import setup_logger, log_info, log_error, log_warning
 # Import custom exceptions explicitly so linters know where they come from
-from custom_exceptions import (
-    QAExtractionError,
-    FileProcessingError,
-    ExcelGenerationError,
-    OCRError,
-    ZipExtractionError,
-    ConfigurationError,
-)
 from file_utils import get_temp_dir, cleanup_temp_files, is_pdf, is_zip, save_txt
 from ocr_utils import extract_text_from_pdf
 from extract.ai_extractor import QAExtractor

--- a/start_tool.py
+++ b/start_tool.py
@@ -277,7 +277,7 @@ def check_and_install_requirements():
                 )
                 if result.returncode != 0:
                     missing_packages.append(package)
-            except:
+            except Exception:
                 missing_packages.append(package)
         
         if not missing_packages:

--- a/tests/test_excel_generator.py
+++ b/tests/test_excel_generator.py
@@ -1,6 +1,7 @@
 import openpyxl
 from pathlib import Path
 from excel_generator import generate_excel
+from custom_exceptions import ExcelGenerationError
 
 
 def test_generate_excel_no_template(tmp_path):
@@ -22,3 +23,12 @@ def test_generate_excel_no_template_returns_path(tmp_path):
     wb = openpyxl.load_workbook(out_file)
     sheet = wb.active
     assert sheet["A2"].alignment.wrap_text
+
+
+def test_generate_excel_no_data_raises(tmp_path):
+    out_file = tmp_path / "out.xlsx"
+    try:
+        generate_excel([], out_file, None)
+    except ExcelGenerationError:
+        return
+    assert False, "ExcelGenerationError not raised"


### PR DESCRIPTION
## Summary
- fix bare except handlers in the GUI and launcher
- split imports and style fixes for Excel generator
- drop unused imports from processing and OCR helpers
- add regression test for Excel generation without data
- run `ruff check` and `pytest`

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a42b9cdd4832e9d7b66ddfc9b2724